### PR TITLE
Enable time in trigger property in Alert component

### DIFF
--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -61,7 +61,7 @@ final class Alert extends Component
             ->textProperty('ACTION', 'DISPLAY')
             ->textProperty('DESCRIPTION', $this->message)
             ->property(
-                new DateTimePropertyType('TRIGGER', $this->triggerAt),
+                new DateTimePropertyType('TRIGGER', $this->triggerAt, true),
                 [new Parameter('VALUE', 'DATE-TIME')]
             );
     }


### PR DESCRIPTION
Hi @rubenvanassche,

The `VALARM ` component's property `TRIGGER` should have time portion when it is relative to start date_time.
Right now it it only generates the date.

### Before
```
BEGIN:VALARM
ACTION:DISPLAY
DESCRIPTION:Buy milk
TRIGGER;VALUE=DATE-TIME:20191218
END:VALARM
```
### After
```
BEGIN:VALARM
ACTION:DISPLAY
DESCRIPTION:Buy milk
TRIGGER;VALUE=DATE-TIME:20191218T114000
END:VALARM
```

Ref:
https://www.kanzaki.com/docs/ical/valarm.html