### PR TITLE
Fix issue with GEO property #10

### DIFF
--- a/src/PropertyTypes/CoordinatesPropertyType.php
+++ b/src/PropertyTypes/CoordinatesPropertyType.php
@@ -32,7 +32,7 @@ class CoordinatesPropertyType extends PropertyType
 
     public function getValue(): string
     {
-        return "{$this->lat},{$this->lng}";
+        return "{$this->lat};{$this->lng}";
     }
 
     public function getOriginalValue(): array

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -130,7 +130,7 @@ class EventTest extends TestCase
 
         $property = $payload->getProperty('X-APPLE-STRUCTURED-LOCATION');
 
-        $this->assertEquals('51.2343,4.4287', $property->getValue());
+        $this->assertEquals('51.2343;4.4287', $property->getValue());
         $this->assertEquals([
             'lat' => 51.2343,
             'lng' => 4.4287,

--- a/tests/PropertyTypes/CoordinatesPropertyTypeTest.php
+++ b/tests/PropertyTypes/CoordinatesPropertyTypeTest.php
@@ -13,7 +13,7 @@ class CoordinatesPropertyTypeTest extends TestCase
         $propertyType = new CoordinatesPropertyType('GEO', 10.5, 20.5);
 
         $this->assertEquals(['GEO'], $propertyType->getNames());
-        $this->assertEquals('10.5,20.5', $propertyType->getValue());
+        $this->assertEquals('10.5;20.5', $propertyType->getValue());
         $this->assertEquals([
             'lat' => 10.5,
             'lng' => 20.5,


### PR DESCRIPTION
Hi @rubenvanassche,

There is an issue with GEO property.
Spec requires to have `;`

https://www.kanzaki.com/docs/ical/geo.html

Before
```
GEO:29.9614608,78.0445989
```

After
```
GEO:29.9614608;78.0445989
```
Validated on
https://icalendar.org/validator.html

Closes #10

Please tag a new version after merging this PR.


