### PR TITLE
add/Ability to set an URL into EVENT

### DIFF
--- a/src/ComponentPayload.php
+++ b/src/ComponentPayload.php
@@ -9,6 +9,7 @@ use Spatie\IcalendarGenerator\Components\Component;
 use Spatie\IcalendarGenerator\PropertyTypes\DateTimePropertyType;
 use Spatie\IcalendarGenerator\PropertyTypes\PropertyType;
 use Spatie\IcalendarGenerator\PropertyTypes\TextPropertyType;
+use Spatie\IcalendarGenerator\PropertyTypes\UriPropertyType;
 
 final class ComponentPayload
 {
@@ -79,6 +80,23 @@ final class ComponentPayload
         }
 
         return $this->property(new TextPropertyType($names, $value, $disableEscaping));
+    }
+
+    /**
+     * @param array|string $names
+     * @param string|null $value
+     *
+     * @return \Spatie\IcalendarGenerator\ComponentPayload
+     */
+    public function uriProperty(
+        $names,
+        ?string $value
+    ): ComponentPayload {
+        if ($value === null) {
+            return $this;
+        }
+
+        return $this->property(new UriPropertyType($names, $value)) ?: $this;
     }
 
     public function subComponent(Component ...$components): ComponentPayload

--- a/src/ComponentPayload.php
+++ b/src/ComponentPayload.php
@@ -96,7 +96,7 @@ final class ComponentPayload
             return $this;
         }
 
-        return $this->property(new UriPropertyType($names, $value)) ?: $this;
+        return filter_var($value, FILTER_VALIDATE_URL) ? $this->property(new UriPropertyType($names, $value)) : $this;
     }
 
     public function subComponent(Component ...$components): ComponentPayload

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -69,6 +69,9 @@ final class Event extends Component
     /** @var \Spatie\IcalendarGenerator\Enums\EventStatus|null */
     private $status = null;
 
+    /** @var string|null */
+    private $url;
+
     public static function create(string $name = null): Event
     {
         return new self($name);
@@ -244,6 +247,13 @@ final class Event extends Component
         return $this;
     }
 
+    public function uniformResourceLocator(string $url): Event
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
     protected function payload(): ComponentPayload
     {
         $payload = ComponentPayload::create($this->getComponentType())
@@ -254,6 +264,7 @@ final class Event extends Component
             ->textProperty('CLASS', $this->classification)
             ->textProperty('TRANSP', $this->transparent ? 'TRANSPARENT' : null)
             ->textProperty('STATUS', $this->status)
+            ->uriProperty('URL', $this->url)
             ->dateTimeProperty('DTSTART', $this->starts, ! $this->isFullDay, $this->withTimezone)
             ->dateTimeProperty('DTEND', $this->ends, ! $this->isFullDay, $this->withTimezone)
             ->dateTimeProperty('DTSTAMP', $this->created, true, $this->withTimezone)

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -247,7 +247,7 @@ final class Event extends Component
         return $this;
     }
 
-    public function uniformResourceLocator(string $url): Event
+    public function url(string $url): Event
     {
         $this->url = $url;
 

--- a/src/PropertyTypes/UriPropertyType.php
+++ b/src/PropertyTypes/UriPropertyType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\IcalendarGenerator\PropertyTypes;
+
+final class UriPropertyType extends PropertyType
+{
+    /** @var string */
+    private $uri;
+
+
+    public static function create($names, string $uri): URIPropertyType
+    {
+        return new self($names, $uri);
+    }
+
+    /**
+     * URIPropertyType constructor.
+     *
+     * @param array|string $names
+     * @param uri $uri
+     */
+    public function __construct($names, string $uri)
+    {
+        parent::__construct($names);
+
+        $this->uri = $uri;
+    }
+
+    public function getValue(): string
+    {
+        return filter_var($this->uri, FILTER_VALIDATE_URL) ? $this->uri : '';
+    }
+
+    public function getOriginalValue(): string
+    {
+        return $this->uri;
+    }
+}

--- a/src/PropertyTypes/UriPropertyType.php
+++ b/src/PropertyTypes/UriPropertyType.php
@@ -28,7 +28,7 @@ final class UriPropertyType extends PropertyType
 
     public function getValue(): string
     {
-        return filter_var($this->uri, FILTER_VALIDATE_URL) ? $this->uri : '';
+        return $this->uri;
     }
 
     public function getOriginalValue(): string

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -38,6 +38,7 @@ class EventTest extends TestCase
         $payload = Event::create('An introduction into event sourcing')
             ->description('By Freek Murze')
             ->createdAt($dateCreated)
+            ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
             ->uniqueIdentifier('Identifier here')
             ->startsAt($dateStarts)
             ->endsAt($dateEnds)
@@ -45,7 +46,7 @@ class EventTest extends TestCase
             ->addressName('Spatie')
             ->resolvePayload();
 
-        $this->assertCount(7, $payload->getProperties());
+        $this->assertCount(8, $payload->getProperties());
 
         $this->assertPropertyEqualsInPayload('SUMMARY', 'An introduction into event sourcing', $payload);
         $this->assertPropertyEqualsInPayload('DESCRIPTION', 'By Freek Murze', $payload);
@@ -54,6 +55,7 @@ class EventTest extends TestCase
         $this->assertPropertyEqualsInPayload('DTEND', $dateEnds, $payload);
         $this->assertPropertyEqualsInPayload('LOCATION', 'Antwerp', $payload);
         $this->assertPropertyEqualsInPayload('UID', 'Identifier here', $payload);
+        $this->assertPropertyEqualsInPayload('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics', $payload);
     }
 
     /** @test */
@@ -250,5 +252,15 @@ class EventTest extends TestCase
             ->resolvePayload();
 
         $this->assertPropertyEqualsInPayload('LOCATION', 'Antwerp', $payload);
+    }
+
+    /** @test */
+    public function it_can_set_a_url()
+    {
+        $payload = Event::create()
+            ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
+            ->resolvePayload();
+
+        $this->assertPropertyEqualsInPayload('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics', $payload);
     }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -38,7 +38,7 @@ class EventTest extends TestCase
         $payload = Event::create('An introduction into event sourcing')
             ->description('By Freek Murze')
             ->createdAt($dateCreated)
-            ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
+            ->url('http://example.com/pub/calendars/jsmith/mytime.ics')
             ->uniqueIdentifier('Identifier here')
             ->startsAt($dateStarts)
             ->endsAt($dateEnds)
@@ -258,9 +258,19 @@ class EventTest extends TestCase
     public function it_can_set_a_url()
     {
         $payload = Event::create()
-            ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
+            ->url('http://example.com/pub/calendars/jsmith/mytime.ics')
             ->resolvePayload();
 
         $this->assertPropertyEqualsInPayload('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics', $payload);
+    }
+
+    /** @test */
+    public function it_ignores_a_wrong_url()
+    {
+        $payload = Event::create()
+            ->url('xample.com/pub/calendars/jsmith/mytime.ics')
+            ->resolvePayload();
+
+        $this->assertPropertyNotInPayload('URL', $payload);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -28,6 +28,7 @@ class IntegrationTest extends TestCase
                     ->address('Samberstraat 69D, 2060 Antwerp, Belgium')
                     ->addressName('Spatie HQ')
                     ->coordinates(51.2343, 4.4287)
+                    ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
                     ->alertMinutesBefore(5, 'Laracon online is going to start in five mintutes')
                     ->alertMinutesAfter(5, 'Laracon online has ended, see you next year!')
                     ->organizer('ruben@spatie.be', 'Ruben')
@@ -75,6 +76,7 @@ LOCATION:Samberstraat 69D\, 2060 Antwerp\, Belgium\r
 CLASS:PUBLIC\r
 TRANSP:TRANSPARENT\r
 STATUS:TENTATIVE\r
+URL:http://example.com/pub/calendars/jsmith/mytime.ics\r
 DTSTART:20190306T150000Z\r
 DTEND:20190306T160000Z\r
 DTSTAMP:20190306T160000Z\r

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -28,7 +28,7 @@ class IntegrationTest extends TestCase
                     ->address('Samberstraat 69D, 2060 Antwerp, Belgium')
                     ->addressName('Spatie HQ')
                     ->coordinates(51.2343, 4.4287)
-                    ->uniformResourceLocator('http://example.com/pub/calendars/jsmith/mytime.ics')
+                    ->url('http://example.com/pub/calendars/jsmith/mytime.ics')
                     ->alertMinutesBefore(5, 'Laracon online is going to start in five mintutes')
                     ->alertMinutesAfter(5, 'Laracon online has ended, see you next year!')
                     ->organizer('ruben@spatie.be', 'Ruben')
@@ -56,7 +56,8 @@ class IntegrationTest extends TestCase
                     ->uniqueIdentifier('uuid')
                     ->createdAt(new DateTime('6 March 2019 16:00:00'))
                     ->startsAt(new DateTime('6 march 2019', new DateTimeZone('Europe/Brussels')))
-                    ->withTimezone();
+                    ->withTimezone()
+                    ->url('wrong.uri/is?set=true');
             })
             ->get();
 

--- a/tests/PropertyTypes/UriPropertyTypeTest.php
+++ b/tests/PropertyTypes/UriPropertyTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Spatie\IcalendarGenerator\Tests\PropertyTypes;
+
+use Spatie\IcalendarGenerator\PropertyTypes\UriPropertyType;
+use Spatie\IcalendarGenerator\Tests\TestCase;
+
+class UriPropertyTypeTest extends TestCase
+{
+    /** @test */
+    public function it_accepts_only_valid_uri()
+    {
+        $this->assertEquals(
+            'http://this.is/a/valid/uri',
+            (new UriPropertyType('', 'http://this.is/a/valid/uri'))->getValue()
+        );
+
+        $this->assertEquals(
+            'foo://example.com:8042/over/there?name=ferret#nose',
+            (new UriPropertyType('', 'foo://example.com:8042/over/there?name=ferret#nose'))->getValue()
+        );
+
+        $this->assertEquals(
+            null,
+            (new UriPropertyType('', 'wrong.uri/is?set=true'))->getValue()
+        );
+    }
+}

--- a/tests/PropertyTypes/UriPropertyTypeTest.php
+++ b/tests/PropertyTypes/UriPropertyTypeTest.php
@@ -8,7 +8,7 @@ use Spatie\IcalendarGenerator\Tests\TestCase;
 class UriPropertyTypeTest extends TestCase
 {
     /** @test */
-    public function it_accepts_only_valid_uri()
+    public function it_accepts_an_uri()
     {
         $this->assertEquals(
             'http://this.is/a/valid/uri',
@@ -18,11 +18,6 @@ class UriPropertyTypeTest extends TestCase
         $this->assertEquals(
             'foo://example.com:8042/over/there?name=ferret#nose',
             (new UriPropertyType('', 'foo://example.com:8042/over/there?name=ferret#nose'))->getValue()
-        );
-
-        $this->assertEquals(
-            null,
-            (new UriPropertyType('', 'wrong.uri/is?set=true'))->getValue()
         );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,11 @@ abstract class TestCase extends BaseTestCase
         $this->assertNotNull($componentPayload->getProperty($name));
     }
 
+    protected function assertPropertyNotInPayload(string $name, ComponentPayload $componentPayload): void
+    {
+        $this->assertObjectNotHasAttribute($name, $componentPayload);
+    }
+
     protected function assertPropertyEqualsInPayload(string $name, $value, ComponentPayload $componentPayload): void
     {
         $this->assertEquals($value, $componentPayload->getProperty($name)->getOriginalValue());


### PR DESCRIPTION
- adds the ability to set an URL into an EVENT as requested in #26
- the URL Property (https://tools.ietf.org/html/rfc5545#section-3.3.13) is implemented as an `UriPropertyType`
- adds an `UriPropertyType` as described in https://tools.ietf.org/html/rfc3986 (Syntax here: https://tools.ietf.org/html/rfc3986#section-3)
- adds a test for adding an URL (`it_can_set_a_url()`), for testing the `UriPropertyType` (`it_accepts_only_valid_uri()`) and extends the `IntegrationTest` (`it_can_create_a_calendar()`)