### PR TITLE
Handle case when getTransitions() returns a false value 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "larapack/dd" : "^1.0",
         "phpunit/phpunit" : "^8.2",
         "spatie/phpunit-snapshot-assertions" : "^4.2",
-        "vimeo/psalm" : "^3.12"
+        "vimeo/psalm" : "^4.3"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Timezones/TimezoneTransitionsResolver.php
+++ b/src/Timezones/TimezoneTransitionsResolver.php
@@ -38,7 +38,17 @@ class TimezoneTransitionsResolver
             $this->end->getTimestamp(),
         );
 
-        if (count($transitions) === 1) {
+        // for timezone '+00:00' DateTimeZone::getTransitions() returns boolean false,
+        // so check for that first and create the fake entry to make it work
+        if ($transitions === false) {
+            $transitions = [[
+                'isdst' => false,
+                'offset' => 0,
+                'ts' => $this->start->getTimestamp(),
+                'abbr' => 'UTC'
+            ]];
+
+        } else if (count($transitions) === 1) {
             // Add a fake transition for UTC for example which does not have transitions
             $transitions[] = [
                 'isdst' => $transitions[0]["isdst"],


### PR DESCRIPTION
When an event timezone is set with the timezone format "+00:00", the DateTimeZone::getTransitions() function returns a boolean false value.  Added a case to handle that instead of having php throw an exception.
