### PR TITLE
Fix date timezones on all day events

### DIFF
--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -384,17 +384,19 @@ class Event extends Component implements HasTimezones
                 fn () => UriProperty::create('URL', $this->url)
             )->multiple(
                 $this->recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
             )->multiple(
                 $this->excluded_recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
             );
 
         return $this;
     }
 
-    private static function dateTimePropertyWithSpecifiedType(string $name, DateTimeValue $dateTimeValue): DateTimeProperty
-    {
+    private static function dateTimePropertyWithSpecifiedType(
+        string $name,
+        DateTimeValue $dateTimeValue
+    ): DateTimeProperty {
         $property = DateTimeProperty::create($name, $dateTimeValue);
         if ($dateTimeValue->hasTime()) {
             $property->addParameter(Parameter::create('VALUE', 'DATE-TIME'));

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -384,17 +384,23 @@ class Event extends Component implements HasTimezones
                 fn () => UriProperty::create('URL', $this->url)
             )->multiple(
                 $this->recurrence_dates,
-                fn (DateTimeValue $dateTime) => DateTimeProperty::create('RDATE', $dateTime)->addParameter(
-                    Parameter::create('VALUE', $dateTime->hasTime() ? 'DATE-TIME' : 'DATE')
-                )
+                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
             )->multiple(
                 $this->excluded_recurrence_dates,
-                fn (DateTimeValue $dateTime) => DateTimeProperty::create('EXDATE', $dateTime)->addParameter(
-                    Parameter::create('VALUE', $dateTime->hasTime() ? 'DATE-TIME' : 'DATE')
-                )
+                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
             );
 
         return $this;
+    }
+
+    private static function dateTimePropertyWithSpecifiedType(string $name, DateTimeValue $dateTimeValue): DateTimeProperty
+    {
+        $property = DateTimeProperty::create($name, $dateTimeValue);
+        if ($dateTimeValue->hasTime()) {
+            $property->addParameter(Parameter::create('VALUE', 'DATE-TIME'));
+        }
+
+        return $property;
     }
 
     private function resolveDateProperty(ComponentPayload $payload, ?DateTimeValue $value, string $name): self

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -14,7 +14,6 @@ use Spatie\IcalendarGenerator\Properties\AppleLocationCoordinatesProperty;
 use Spatie\IcalendarGenerator\Properties\CalendarAddressProperty;
 use Spatie\IcalendarGenerator\Properties\CoordinatesProperty;
 use Spatie\IcalendarGenerator\Properties\DateTimeProperty;
-use Spatie\IcalendarGenerator\Properties\EmptyProperty;
 use Spatie\IcalendarGenerator\Properties\Parameter;
 use Spatie\IcalendarGenerator\Properties\RRuleProperty;
 use Spatie\IcalendarGenerator\Properties\TextProperty;
@@ -404,15 +403,9 @@ class Event extends Component implements HasTimezones
             return $this;
         }
 
-        if (! $this->isFullDay) {
-            $payload->property(DateTimeProperty::create($name, $value, $this->withoutTimezone));
-
-            return $this;
-        }
-
-        $payload->property(EmptyProperty::create($name, [
-            Parameter::create('VALUE', DateTimeValue::create($value->getDateTime(), false)),
-        ]));
+        $payload->property(
+            DateTimeProperty::fromDateTime($name, $value->getDateTime(), !$this->isFullDay, $this->withoutTimezone)
+        );
 
         return $this;
     }

--- a/src/Properties/DateTimeProperty.php
+++ b/src/Properties/DateTimeProperty.php
@@ -38,7 +38,7 @@ class DateTimeProperty extends Property
         $this->dateTimeValue = $dateTimeValue;
         $this->dateTimeZone = $dateTimeValue->getDateTime()->getTimezone();
 
-        if ($withoutTimeZone || ! $dateTimeValue->hasTime() || $this->isUTC()) {
+        if ($withoutTimeZone || $this->isUTC()) {
             return;
         }
 

--- a/src/Properties/DateTimeProperty.php
+++ b/src/Properties/DateTimeProperty.php
@@ -45,7 +45,6 @@ class DateTimeProperty extends Property
         if (!$dateTimeValue->hasTime()) {
             $this->addParameter(new Parameter('VALUE', 'DATE'));
         }
-
     }
 
     public function getValue(): string

--- a/src/Properties/DateTimeProperty.php
+++ b/src/Properties/DateTimeProperty.php
@@ -38,11 +38,14 @@ class DateTimeProperty extends Property
         $this->dateTimeValue = $dateTimeValue;
         $this->dateTimeZone = $dateTimeValue->getDateTime()->getTimezone();
 
-        if ($withoutTimeZone || $this->isUTC()) {
-            return;
+        if (!$withoutTimeZone && !$this->isUTC()) {
+            $this->addParameter(new Parameter('TZID', $this->dateTimeZone->getName()));
         }
 
-        $this->addParameter(new Parameter('TZID', $this->dateTimeZone->getName()));
+        if (!$dateTimeValue->hasTime()) {
+            $this->addParameter(new Parameter('VALUE', 'DATE'));
+        }
+
     }
 
     public function getValue(): string

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -89,11 +89,31 @@ class EventTest extends TestCase
             ->period($dateStarts, $dateEnds)
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('DTSTART', null, $payload);
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE:20190517', $payload->getProperty('DTSTART'));
+        $this->assertParameterCountInProperty(1, $payload->getProperty('DTSTART'));
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
 
-        $this->assertPropertyEqualsInPayload('DTEND', null, $payload);
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE:20190518', $payload->getProperty('DTEND'));
+        $this->assertParameterCountInProperty(1, $payload->getProperty('DTEND'));
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTEND'));
+    }
+
+    /** @test */
+    public function an_event_can_be_a_full_day_with_timezones()
+    {
+        $dateStarts = new DateTime('17 may 2019', new DateTimeZone('Europe/London'));
+        $dateEnds = new DateTime('18 may 2019', new DateTimeZone('Europe/London'));
+
+        $payload = Event::create('An introduction into event sourcing')
+            ->fullDay()
+            ->period($dateStarts, $dateEnds)
+            ->resolvePayload();
+
+        $this->assertParameterCountInProperty(2, $payload->getProperty('DTSTART'));
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
+        $this->assertParameterEqualsInProperty('TZID', 'Europe/London', $payload->getProperty('DTSTART'));
+
+        $this->assertParameterCountInProperty(2, $payload->getProperty('DTEND'));
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTEND'));
+        $this->assertParameterEqualsInProperty('TZID', 'Europe/London', $payload->getProperty('DTEND'));
     }
 
     /** @test */
@@ -106,8 +126,8 @@ class EventTest extends TestCase
             ->startsAt($dateStarts)
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('DTSTART', null, $payload);
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE:20190517', $payload->getProperty('DTSTART'));
+        $this->assertParameterCountInProperty(1, $payload->getProperty('DTSTART'));
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
 
         $this->assertPropertyNotInPayload('DTEND', $payload);
     }
@@ -392,14 +412,12 @@ class EventTest extends TestCase
         );
 
         $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateC, false))
-                ->addParameter(Parameter::create('VALUE', 'DATE')),
+            DateTimeProperty::create('RDATE', DateTimeValue::create($dateC, false)),
             $properties
         );
 
         $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateD, false))
-                ->addParameter(Parameter::create('VALUE', 'DATE')),
+            DateTimeProperty::create('RDATE', DateTimeValue::create($dateD, false)),
             $properties
         );
     }
@@ -448,14 +466,12 @@ class EventTest extends TestCase
         );
 
         $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateC, false))
-                ->addParameter(Parameter::create('VALUE', 'DATE')),
+            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateC, false)),
             $properties
         );
 
         $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateD, false))
-                ->addParameter(Parameter::create('VALUE', 'DATE')),
+            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateD, false)),
             $properties
         );
     }

--- a/tests/Properties/DateTimePropertyTest.php
+++ b/tests/Properties/DateTimePropertyTest.php
@@ -56,10 +56,8 @@ class DateTimePropertyTest extends TestCase
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date);
 
         $this->assertEquals('20190516', $property->getValue());
-
-        foreach ($property->getParameters() as $parameter) {
-            self::assertNotSame('TZID', $parameter->getName());
-        }
+        $this->assertParameterCountInProperty(1, $property);
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $property);
     }
 
     /** @test */

--- a/tests/Properties/DateTimePropertyTest.php
+++ b/tests/Properties/DateTimePropertyTest.php
@@ -60,6 +60,16 @@ class DateTimePropertyTest extends TestCase
     }
 
     /** @test */
+    public function it_will_use_a_non_utc_timezone_format_when_time_is_not_given()
+    {
+        $property = DateTimeProperty::fromDateTime('STARTS', $this->date, false);
+
+        $this->assertEquals('20190516', $property->getValue());
+        $this->assertCount(1, $property->getParameters());
+        $this->assertParameterEqualsInProperty('TZID', 'Europe/Brussels', $property);
+    }
+
+    /** @test */
     public function it_will_format_the_date_and_time_correctly_with_a_conversion_to_another_timezone()
     {
         $this->date->setTimezone(new DateTimeZone('Europe/Brussels'));

--- a/tests/Properties/DateTimePropertyTest.php
+++ b/tests/Properties/DateTimePropertyTest.php
@@ -56,7 +56,10 @@ class DateTimePropertyTest extends TestCase
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date);
 
         $this->assertEquals('20190516', $property->getValue());
-        $this->assertCount(0, $property->getParameters());
+
+        foreach ($property->getParameters() as $parameter) {
+            self::assertNotSame('TZID', $parameter->getName());
+        }
     }
 
     /** @test */
@@ -65,8 +68,9 @@ class DateTimePropertyTest extends TestCase
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, false);
 
         $this->assertEquals('20190516', $property->getValue());
-        $this->assertCount(1, $property->getParameters());
+        $this->assertCount(2, $property->getParameters());
         $this->assertParameterEqualsInProperty('TZID', 'Europe/Brussels', $property);
+        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $property);
     }
 
     /** @test */


### PR DESCRIPTION
Hello, I have noticed an issue when creating all-day events. The Date properties lose their timezones when defined within an all-day event. This happens due to how a DateTimeProperty decides to append the TZID parameter and how the resolveDateTimeProperty method Resolves a Date time property without a date.

The changes on my branch are the following:

- The resolveDateTimeProperty now always returns a DateTimeProperty, whereas before it could return an empty property with a VALUE parameter of type DATE.
- DateTimeProperty only checks if it has a false withoutTimeZone flag and that it is not UTC before adding a TZID parameter. A VALUE parameter of type DATE is added if the DateTimeValue doesn’t have a time.
- To maintain current behaviour, the EXDATE and RDATE properties specify a VALUE parameter of type DATE-TIME if the DateTimeValue does have a time.
- I have added tests to assert a TZID is added to a start/end date when it is 

Whilst researching the behaviour of iCalendar all-day events and timezones, I have found that mail clients handle timezones for all-day events in one of two ways. Gmail - at the time the referenced post was created - displays all-day events with no timezone consideration ([reference](https://support.google.com/calendar/thread/24874991/how-to-create-time-zone-agnostic-all-day-calendar-events?hl=en)) but older versions of outlook do shift all-day events by timezone ([reference](https://social.technet.microsoft.com/Forums/lync/en-US/2a0e022b-b216-49d9-a421-f32ab74238ae/all-day-calendar-events-and-different-time-zones?forum=outlook)). Furthermore, RCFF 5455 3.8.2.4 ([reference](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4)) details date-time start properties to be able to have a TZID parameter and does not mention any conditions where this should not be supplied.

I have noticed a test that asserts that a TZID parameter is not added to a DTSTART when it does not have the time and the timezone is UTC. I am unsure if this is to make sure that no TZID is included when DTSTART doesn’t have a time, or whether it shouldn’t have a TZID if the timezone is UTC. 

Let me know if there are any misunderstandings, or feedback.

Thank you for your time.