### PR TITLE
Add expectation testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `icalendar-generator` will be documented in this file
 
+## 2.3.0 - 2020-08-20
+
+- add support for attachments on events
+- add a new expectation testing mechanism for internal tests
+
 ## 2.2.2 - 2020-08-19
 
 - fix date timezones on all day events (#55)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Event::create()
     ...
 ```
 
+You can add an attachment as such:
+
+```php
+Event::create()
+    ->attachment('https://spatie.be/logo.svg')
+    ->attachment('https://spatie.be/feed.xml', 'application/json')
+    ...
+```
+
 After creating your event, it should be added to a calendar. There are multiple options to do this:
 
 ``` php

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "larapack/dd" : "^1.0",
         "phpunit/phpunit" : "^8.2",
         "spatie/phpunit-snapshot-assertions" : "^4.2",
-        "vimeo/psalm" : "^4.3"
+        "vimeo/psalm" : "^4.3",
+        "ext-json" : "*"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/ComponentPayload.php
+++ b/src/ComponentPayload.php
@@ -73,7 +73,13 @@ class ComponentPayload
         return $this->properties;
     }
 
-    public function getProperty(string $name): Property
+    /**
+     * @param string $name
+     *
+     * @return Property[]|Property
+     * @throws \Exception
+     */
+    public function getProperty(string $name)
     {
         $filteredProperties = array_filter(
             $this->properties,
@@ -88,7 +94,11 @@ class ComponentPayload
             throw new Exception("Property `{$name}` does not exist in the payload");
         }
 
-        return $properties[0];
+        if(count($properties) === 1){
+            return $properties[0];
+        }
+
+        return $properties;
     }
 
     public function getSubComponents(): array

--- a/src/ComponentPayload.php
+++ b/src/ComponentPayload.php
@@ -94,7 +94,7 @@ class ComponentPayload
             throw new Exception("Property `{$name}` does not exist in the payload");
         }
 
-        if(count($properties) === 1){
+        if (count($properties) === 1) {
             return $properties[0];
         }
 

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -278,7 +278,7 @@ class Event extends Component implements HasTimezones
     public function doNotRepeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -296,7 +296,7 @@ class Event extends Component implements HasTimezones
     public function repeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -358,55 +358,55 @@ class Event extends Component implements HasTimezones
             ->property(DateTimeProperty::create('DTSTAMP', $this->created, $this->withoutTimezone))
             ->optional(
                 $this->name,
-                fn() => TextProperty::create('SUMMARY', $this->name)
+                fn () => TextProperty::create('SUMMARY', $this->name)
             )
             ->optional(
                 $this->description,
-                fn() => TextProperty::create('DESCRIPTION', $this->description)
+                fn () => TextProperty::create('DESCRIPTION', $this->description)
             )
             ->optional(
                 $this->address,
-                fn() => TextProperty::create('LOCATION', $this->address)
+                fn () => TextProperty::create('LOCATION', $this->address)
             )
             ->optional(
                 $this->classification,
-                fn() => TextProperty::createFromEnum('CLASS', $this->classification)
+                fn () => TextProperty::createFromEnum('CLASS', $this->classification)
             )
             ->optional(
                 $this->status,
-                fn() => TextProperty::createFromEnum('STATUS', $this->status)
+                fn () => TextProperty::createFromEnum('STATUS', $this->status)
             )
             ->optional(
                 $this->transparent,
-                fn() => TextProperty::create('TRANSP', 'TRANSPARENT')
+                fn () => TextProperty::create('TRANSP', 'TRANSPARENT')
             )
             ->optional(
                 $this->organizer,
-                fn() => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
+                fn () => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
             )
             ->optional(
                 $this->rrule,
-                fn() => RRuleProperty::create('RRULE', $this->rrule)
+                fn () => RRuleProperty::create('RRULE', $this->rrule)
             )
             ->multiple(
                 $this->attendees,
-                fn(CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
+                fn (CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
             )
             ->optional(
                 $this->url,
-                fn() => UriProperty::create('URL', $this->url)
+                fn () => UriProperty::create('URL', $this->url)
             )
             ->multiple(
                 $this->recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
             )
             ->multiple(
                 $this->excluded_recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
             )
             ->multiple(
                 $this->attachments,
-                fn(array $attachment) => $attachment['type'] !== null
+                fn (array $attachment) => $attachment['type'] !== null
                     ? UriProperty::create('ATTACH', $attachment['url'])->addParameter(Parameter::create('FMTTYPE', $attachment['type']))
                     : UriProperty::create('ATTACH', $attachment['url'])
             );
@@ -466,7 +466,7 @@ class Event extends Component implements HasTimezones
     private function resolveAlerts(ComponentPayload $payload): self
     {
         $alerts = array_map(
-            fn(Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
+            fn (Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
             $this->alerts
         );
 

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -278,7 +278,7 @@ class Event extends Component implements HasTimezones
     public function doNotRepeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -296,7 +296,7 @@ class Event extends Component implements HasTimezones
     public function repeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -355,55 +355,55 @@ class Event extends Component implements HasTimezones
             ->property(DateTimeProperty::create('DTSTAMP', $this->created, $this->withoutTimezone))
             ->optional(
                 $this->name,
-                fn() => TextProperty::create('SUMMARY', $this->name)
+                fn () => TextProperty::create('SUMMARY', $this->name)
             )
             ->optional(
                 $this->description,
-                fn() => TextProperty::create('DESCRIPTION', $this->description)
+                fn () => TextProperty::create('DESCRIPTION', $this->description)
             )
             ->optional(
                 $this->address,
-                fn() => TextProperty::create('LOCATION', $this->address)
+                fn () => TextProperty::create('LOCATION', $this->address)
             )
             ->optional(
                 $this->classification,
-                fn() => TextProperty::createFromEnum('CLASS', $this->classification)
+                fn () => TextProperty::createFromEnum('CLASS', $this->classification)
             )
             ->optional(
                 $this->status,
-                fn() => TextProperty::createFromEnum('STATUS', $this->status)
+                fn () => TextProperty::createFromEnum('STATUS', $this->status)
             )
             ->optional(
                 $this->transparent,
-                fn() => TextProperty::create('TRANSP', 'TRANSPARENT')
+                fn () => TextProperty::create('TRANSP', 'TRANSPARENT')
             )
             ->optional(
                 $this->organizer,
-                fn() => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
+                fn () => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
             )
             ->optional(
                 $this->rrule,
-                fn() => RRuleProperty::create('RRULE', $this->rrule)
+                fn () => RRuleProperty::create('RRULE', $this->rrule)
             )
             ->multiple(
                 $this->attendees,
-                fn(CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
+                fn (CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
             )
             ->optional(
                 $this->url,
-                fn() => UriProperty::create('URL', $this->url)
+                fn () => UriProperty::create('URL', $this->url)
             )
             ->multiple(
                 $this->recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
             )
             ->multiple(
                 $this->excluded_recurrence_dates,
-                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
+                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
             )
             ->multiple(
                 $this->attachments,
-                fn(string $url) => UriProperty::create('ATTACH', $url)
+                fn (string $url) => UriProperty::create('ATTACH', $url)
             );
 
         return $this;
@@ -461,7 +461,7 @@ class Event extends Component implements HasTimezones
     private function resolveAlerts(ComponentPayload $payload): self
     {
         $alerts = array_map(
-            fn(Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
+            fn (Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
             $this->alerts
         );
 

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -73,7 +73,7 @@ class Event extends Component implements HasTimezones
 
     private ?string $url = null;
 
-    /** @var string[] */
+    /** @var array[] */
     private array $attachments = [];
 
     public static function create(string $name = null): Event
@@ -278,7 +278,7 @@ class Event extends Component implements HasTimezones
     public function doNotRepeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -296,7 +296,7 @@ class Event extends Component implements HasTimezones
     public function repeatOn($dates, bool $withTime = true): self
     {
         $dates = array_map(
-            fn (DateTime $date) => DateTimeValue::create($date, $withTime),
+            fn(DateTime $date) => DateTimeValue::create($date, $withTime),
             is_array($dates) ? $dates : [$dates]
         );
 
@@ -312,9 +312,12 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function attachment(string ...$urls): Event
+    public function attachment(string $url, ?string $mediaType = null): Event
     {
-        $this->attachments = array_merge($this->attachments, $urls);
+        $this->attachments[] = [
+            'url' => $url,
+            'type' => $mediaType,
+        ];
 
         return $this;
     }
@@ -355,55 +358,57 @@ class Event extends Component implements HasTimezones
             ->property(DateTimeProperty::create('DTSTAMP', $this->created, $this->withoutTimezone))
             ->optional(
                 $this->name,
-                fn () => TextProperty::create('SUMMARY', $this->name)
+                fn() => TextProperty::create('SUMMARY', $this->name)
             )
             ->optional(
                 $this->description,
-                fn () => TextProperty::create('DESCRIPTION', $this->description)
+                fn() => TextProperty::create('DESCRIPTION', $this->description)
             )
             ->optional(
                 $this->address,
-                fn () => TextProperty::create('LOCATION', $this->address)
+                fn() => TextProperty::create('LOCATION', $this->address)
             )
             ->optional(
                 $this->classification,
-                fn () => TextProperty::createFromEnum('CLASS', $this->classification)
+                fn() => TextProperty::createFromEnum('CLASS', $this->classification)
             )
             ->optional(
                 $this->status,
-                fn () => TextProperty::createFromEnum('STATUS', $this->status)
+                fn() => TextProperty::createFromEnum('STATUS', $this->status)
             )
             ->optional(
                 $this->transparent,
-                fn () => TextProperty::create('TRANSP', 'TRANSPARENT')
+                fn() => TextProperty::create('TRANSP', 'TRANSPARENT')
             )
             ->optional(
                 $this->organizer,
-                fn () => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
+                fn() => CalendarAddressProperty::create('ORGANIZER', $this->organizer)
             )
             ->optional(
                 $this->rrule,
-                fn () => RRuleProperty::create('RRULE', $this->rrule)
+                fn() => RRuleProperty::create('RRULE', $this->rrule)
             )
             ->multiple(
                 $this->attendees,
-                fn (CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
+                fn(CalendarAddress $attendee) => CalendarAddressProperty::create('ATTENDEE', $attendee)
             )
             ->optional(
                 $this->url,
-                fn () => UriProperty::create('URL', $this->url)
+                fn() => UriProperty::create('URL', $this->url)
             )
             ->multiple(
                 $this->recurrence_dates,
-                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
+                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('RDATE', $dateTime)
             )
             ->multiple(
                 $this->excluded_recurrence_dates,
-                fn (DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
+                fn(DateTimeValue $dateTime) => self::dateTimePropertyWithSpecifiedType('EXDATE', $dateTime)
             )
             ->multiple(
                 $this->attachments,
-                fn (string $url) => UriProperty::create('ATTACH', $url)
+                fn(array $attachment) => $attachment['type'] !== null
+                    ? UriProperty::create('ATTACH', $attachment['url'])->addParameter(Parameter::create('FMTTYPE', $attachment['type']))
+                    : UriProperty::create('ATTACH', $attachment['url'])
             );
 
         return $this;
@@ -461,7 +466,7 @@ class Event extends Component implements HasTimezones
     private function resolveAlerts(ComponentPayload $payload): self
     {
         $alerts = array_map(
-            fn (Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
+            fn(Alert $alert) => $this->withoutTimezone ? $alert->withoutTimezone() : $alert,
             $this->alerts
         );
 

--- a/tests/ComponentPayloadTest.php
+++ b/tests/ComponentPayloadTest.php
@@ -68,7 +68,10 @@ class ComponentPayloadTest extends TestCase
         $payload->optional(false, fn () => TextProperty::create('text', 'Some text here'));
         $payload->optional(true, fn () => TextProperty::create('text', 'Other text here'));
 
-        $this->assertPropertyEqualsInPayload('text', 'Other text here', $payload);
+        PayloadExpectation::create($payload)->expectPropertyValue(
+            'text',
+            'Other text here'
+        );
     }
 
     /** @test */
@@ -79,7 +82,10 @@ class ComponentPayloadTest extends TestCase
         $payload->optional(null, fn () => TextProperty::create('text', 'Some text here'));
         $payload->optional('something', fn () => TextProperty::create('text', 'Other text here'));
 
-        $this->assertPropertyEqualsInPayload('text', 'Other text here', $payload);
+        PayloadExpectation::create($payload)->expectPropertyValue(
+            'text',
+            'Other text here'
+        );
     }
 
     /** @test */

--- a/tests/Components/AlertTest.php
+++ b/tests/Components/AlertTest.php
@@ -5,6 +5,8 @@ namespace Spatie\IcalendarGenerator\Tests\Components;
 use DateInterval;
 use DateTime;
 use Spatie\IcalendarGenerator\Components\Alert;
+use Spatie\IcalendarGenerator\Tests\PayloadExpectation;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class AlertTest extends TestCase
@@ -16,14 +18,17 @@ class AlertTest extends TestCase
 
         $payload = (new Alert('It is time'))->triggerDate($trigger)->resolvePayload();
 
-        $this->assertEquals('VALARM', $payload->getType());
-        $this->assertCount(3, $payload->getProperties());
-
-        $this->assertPropertyEqualsInPayload('ACTION', 'DISPLAY', $payload);
-        $this->assertPropertyEqualsInPayload('DESCRIPTION', 'It is time', $payload);
-        $this->assertPropertyEqualsInPayload('TRIGGER', $trigger, $payload);
-        $this->assertParameterCountInProperty(1, $payload->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE-TIME', $payload->getProperty('TRIGGER'));
+        PayloadExpectation::create($payload)
+            ->expectType('VALARM')
+            ->expectPropertyCount(3)
+            ->expectPropertyValue('ACTION', 'DISPLAY')
+            ->expectPropertyValue('DESCRIPTION', 'It is time')
+            ->expectProperty('TRIGGER', function(PropertyExpectation  $expectation) use ($trigger) {
+                $expectation
+                    ->expectValue($trigger)
+                    ->expectParameterCount(1)
+                    ->expectParameterValue('VALUE', 'DATE-TIME');
+            });
     }
 
     /** @test */
@@ -36,8 +41,9 @@ class AlertTest extends TestCase
             ->triggerDate($trigger)
             ->resolvePayload();
 
-        $this->assertParameterCountInProperty(1, $payload->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE-TIME', $payload->getProperty('TRIGGER'));
+        PropertyExpectation::create($payload, 'TRIGGER')
+            ->expectParameterCount(1)
+            ->expectParameterValue('VALUE', 'DATE-TIME');
     }
 
     /** @test */
@@ -49,12 +55,13 @@ class AlertTest extends TestCase
             ->triggerAtStart($trigger)
             ->resolvePayload();
 
-        $this->assertEquals('VALARM', $payload->getType());
-        $this->assertCount(2, $payload->getProperties());
-
-        $this->assertPropertyEqualsInPayload('ACTION', 'DISPLAY', $payload);
-        $this->assertPropertyEqualsInPayload('TRIGGER', $trigger, $payload);
-        $this->assertParameterCountInProperty(0, $payload->getProperty('TRIGGER'));
+        PayloadExpectation::create($payload)
+            ->expectType('VALARM')
+            ->expectPropertyCount(2)
+            ->expectPropertyValue('ACTION', 'DISPLAY')
+            ->expectProperty('TRIGGER', function (PropertyExpectation $expectation) use ($trigger) {
+                $expectation->expectValue($trigger)->expectParameterCount(0);
+            });
     }
 
     /** @test */
@@ -66,13 +73,15 @@ class AlertTest extends TestCase
             ->triggerAtEnd($trigger)
             ->resolvePayload();
 
-        $this->assertEquals('VALARM', $payload->getType());
-        $this->assertCount(2, $payload->getProperties());
-
-        $this->assertPropertyEqualsInPayload('ACTION', 'DISPLAY', $payload);
-        $this->assertPropertyEqualsInPayload('TRIGGER', $trigger, $payload);
-        $this->assertParameterCountInProperty(1, $payload->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('RELATED', 'END', $payload->getProperty('TRIGGER'));
+        PayloadExpectation::create($payload)
+            ->expectType('VALARM')
+            ->expectPropertyCount(2)
+            ->expectPropertyValue('ACTION', 'DISPLAY')
+            ->expectProperty('TRIGGER', function (PropertyExpectation $expectation) use ($trigger) {
+                $expectation->expectValue($trigger)
+                    ->expectParameterCount(1)
+                    ->expectParameterValue('RELATED', 'END');
+            });
     }
 
     /** @test */
@@ -83,27 +92,31 @@ class AlertTest extends TestCase
         $payload = Alert::minutesBeforeStart(5)->resolvePayload();
         $interval->invert = 1;
 
-        $this->assertPropertyEqualsInPayload('TRIGGER', $interval, $payload);
-        $this->assertParameterCountInProperty(0, $payload->getProperty('TRIGGER'));
+        PropertyExpectation::create($payload, 'TRIGGER')
+            ->expectValue($interval)
+            ->expectParameterCount(0);
 
         $payload = Alert::minutesAfterStart(5)->resolvePayload();
         $interval->invert = 0;
 
-        $this->assertPropertyEqualsInPayload('TRIGGER', $interval, $payload);
-        $this->assertParameterCountInProperty(0, $payload->getProperty('TRIGGER'));
+        PropertyExpectation::create($payload, 'TRIGGER')
+            ->expectValue($interval)
+            ->expectParameterCount(0);
 
         $payload = Alert::minutesBeforeEnd(5)->resolvePayload();
         $interval->invert = 1;
 
-        $this->assertPropertyEqualsInPayload('TRIGGER', $interval, $payload);
-        $this->assertParameterCountInProperty(1, $payload->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('RELATED', 'END', $payload->getProperty('TRIGGER'));
+        PropertyExpectation::create($payload, 'TRIGGER')
+            ->expectValue($interval)
+            ->expectParameterCount(1)
+            ->expectParameterValue('RELATED', 'END');
 
         $payload = Alert::minutesAfterEnd(5)->resolvePayload();
         $interval->invert = 0;
 
-        $this->assertPropertyEqualsInPayload('TRIGGER', $interval, $payload);
-        $this->assertParameterCountInProperty(1, $payload->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('RELATED', 'END', $payload->getProperty('TRIGGER'));
+        PropertyExpectation::create($payload, 'TRIGGER')
+            ->expectValue($interval)
+            ->expectParameterCount(1)
+            ->expectParameterValue('RELATED', 'END');
     }
 }

--- a/tests/Components/AlertTest.php
+++ b/tests/Components/AlertTest.php
@@ -23,7 +23,7 @@ class AlertTest extends TestCase
             ->expectPropertyCount(3)
             ->expectPropertyValue('ACTION', 'DISPLAY')
             ->expectPropertyValue('DESCRIPTION', 'It is time')
-            ->expectProperty('TRIGGER', function(PropertyExpectation  $expectation) use ($trigger) {
+            ->expectProperty('TRIGGER', function (PropertyExpectation  $expectation) use ($trigger) {
                 $expectation
                     ->expectValue($trigger)
                     ->expectParameterCount(1)

--- a/tests/Components/CalendarTest.php
+++ b/tests/Components/CalendarTest.php
@@ -72,7 +72,7 @@ class CalendarTest extends TestCase
 
         PayloadExpectation::create($payload)
             ->expectSubComponentCount(1)
-            ->expectSubComponent(0, function(PayloadExpectation  $expectation){
+            ->expectSubComponent(0, function (PayloadExpectation  $expectation) {
                 $expectation->expectPropertyValue('SUMMARY', 'An introduction to event sourcing');
             });
     }
@@ -110,10 +110,10 @@ class CalendarTest extends TestCase
 
         PayloadExpectation::create($payload)
             ->expectSubComponentCount(2)
-            ->expectSubComponent(0, function(PayloadExpectation  $expectation){
+            ->expectSubComponent(0, function (PayloadExpectation  $expectation) {
                 $expectation->expectPropertyValue('SUMMARY', 'An introduction to event sourcing');
             })
-            ->expectSubComponent(1, function(PayloadExpectation  $expectation){
+            ->expectSubComponent(1, function (PayloadExpectation  $expectation) {
                 $expectation->expectPropertyValue('SUMMARY', 'Websockets what are they?');
             });
     }
@@ -178,10 +178,10 @@ class CalendarTest extends TestCase
 
         PayloadExpectation::create($payload)
             ->expectSubComponentCount(5)
-            ->expectSubComponent(0, function (PayloadExpectation $expectation){
+            ->expectSubComponent(0, function (PayloadExpectation $expectation) {
                 $expectation->expectType('VTIMEZONE')->expectPropertyValue('TZID', 'UTC');
             })
-            ->expectSubComponent(1, function (PayloadExpectation $expectation){
+            ->expectSubComponent(1, function (PayloadExpectation $expectation) {
                 $expectation->expectType('VTIMEZONE')->expectPropertyValue('TZID', 'Europe/Brussels');
             })
             ->expectSubComponentNotInstanceOf(2, Timezone::class)

--- a/tests/Components/ComponentTest.php
+++ b/tests/Components/ComponentTest.php
@@ -5,6 +5,7 @@ namespace Spatie\IcalendarGenerator\Tests\Components;
 use Spatie\IcalendarGenerator\Components\Alert;
 use Spatie\IcalendarGenerator\Exceptions\InvalidComponent;
 use Spatie\IcalendarGenerator\Properties\TextProperty;
+use Spatie\IcalendarGenerator\Tests\PayloadExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\Tests\TestClasses\DummyComponent;
 
@@ -54,11 +55,8 @@ class ComponentTest extends TestCase
             TextProperty::create('organizer', 'ruben@spatie.be')
         );
 
-        $this->assertPropertyEqualsInPayload(
-            'organizer',
-            'ruben@spatie.be',
-            $dummy->resolvePayload()
-        );
+        PayloadExpectation::create($dummy->resolvePayload())
+            ->expectPropertyValue('organizer', 'ruben@spatie.be');
     }
 
     /** @test */
@@ -66,14 +64,12 @@ class ComponentTest extends TestCase
     {
         $dummy = new DummyComponent('Dummy');
 
-        $component = new Alert();
+        $component = Alert::minutesBeforeEnd(10);
 
         $dummy->appendSubComponent($component);
 
-        $this->assertCount(1, $dummy->resolvePayload()->getSubComponents());
-        $this->assertEquals(
-            $component,
-            $dummy->resolvePayload()->getSubComponents()[0]
-        );
+        PayloadExpectation::create($dummy->resolvePayload())
+            ->expectSubComponentCount(1)
+            ->expectSubComponents($component);
     }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -482,26 +482,18 @@ class EventTest extends TestCase
     {
         $payload = Event::create()
             ->attachment('http://spatie.be/logo.svg')
+            ->attachment('http://spatie.be/logo.jpg', 'application/html')
             ->resolvePayload();
 
-        PayloadExpectation::create($payload)
-            ->expectPropertyValue('ATTACH', 'http://spatie.be/logo.svg');
-    }
-
-    /** @test */
-    public function it_can_add_multiple_attachment_to_an_event()
-    {
-        $payload = Event::create()
-            ->attachment('http://spatie.be/logo.svg', 'http://spatie.be/logo.png')
-            ->attachment('http://spatie.be/logo.jpg')
-            ->resolvePayload();
-
-        PayloadExpectation::create($payload)
-            ->expectPropertyValue(
-                'ATTACH',
-                'http://spatie.be/logo.svg',
-                'http://spatie.be/logo.png',
-                'http://spatie.be/logo.jpg'
-            );
+        PayloadExpectation::create($payload)->expectProperty(
+            'ATTACH',
+            fn(PropertyExpectation $expectation) => $expectation
+                ->expectParameterCount(0)
+                ->expectValue('http://spatie.be/logo.svg'),
+            fn(PropertyExpectation $expectation) => $expectation
+                ->expectParameterCount(1)
+                ->expectParameterValue('FMTTYPE', 'application/html')
+                ->expectValue('http://spatie.be/logo.jpg'),
+        );
     }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -10,12 +10,11 @@ use Spatie\IcalendarGenerator\Enums\Classification;
 use Spatie\IcalendarGenerator\Enums\EventStatus;
 use Spatie\IcalendarGenerator\Enums\ParticipationStatus;
 use Spatie\IcalendarGenerator\Enums\RecurrenceFrequency;
-use Spatie\IcalendarGenerator\Properties\CalendarAddressProperty;
 use Spatie\IcalendarGenerator\Properties\DateTimeProperty;
-use Spatie\IcalendarGenerator\Properties\Parameter;
+use Spatie\IcalendarGenerator\Tests\PayloadExpectation;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\ValueObjects\CalendarAddress;
-use Spatie\IcalendarGenerator\ValueObjects\DateTimeValue;
 use Spatie\IcalendarGenerator\ValueObjects\RRule;
 
 class EventTest extends TestCase
@@ -25,13 +24,11 @@ class EventTest extends TestCase
     {
         $payload = Event::create()->resolvePayload();
 
-        $properties = $payload->getProperties();
-
-        $this->assertEquals('VEVENT', $payload->getType());
-        $this->assertCount(2, $properties);
-
-        $this->assertPropertyExistInPayload('UID', $payload);
-        $this->assertPropertyExistInPayload('DTSTAMP', $payload);
+        PayloadExpectation::create($payload)
+            ->expectType('VEVENT')
+            ->expectPropertyCount(2)
+            ->expectPropertyExists('UID')
+            ->expectPropertyExists('DTSTAMP');
     }
 
     /** @test */
@@ -52,16 +49,16 @@ class EventTest extends TestCase
             ->addressName('Spatie')
             ->resolvePayload();
 
-        $this->assertCount(8, $payload->getProperties());
-
-        $this->assertPropertyEqualsInPayload('SUMMARY', 'An introduction into event sourcing', $payload);
-        $this->assertPropertyEqualsInPayload('DESCRIPTION', 'By Freek Murze', $payload);
-        $this->assertPropertyEqualsInPayload('DTSTAMP', $dateCreated, $payload);
-        $this->assertPropertyEqualsInPayload('DTSTART', $dateStarts, $payload);
-        $this->assertPropertyEqualsInPayload('DTEND', $dateEnds, $payload);
-        $this->assertPropertyEqualsInPayload('LOCATION', 'Antwerp', $payload);
-        $this->assertPropertyEqualsInPayload('UID', 'Identifier here', $payload);
-        $this->assertPropertyEqualsInPayload('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyCount(8)
+            ->expectPropertyValue('SUMMARY', 'An introduction into event sourcing')
+            ->expectPropertyValue('DESCRIPTION', 'By Freek Murze')
+            ->expectPropertyValue('DTSTAMP', $dateCreated)
+            ->expectPropertyValue('DTSTART', $dateStarts)
+            ->expectPropertyValue('DTEND', $dateEnds)
+            ->expectPropertyValue('LOCATION', 'Antwerp')
+            ->expectPropertyValue('UID', 'Identifier here')
+            ->expectPropertyValue('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics');
     }
 
     /** @test */
@@ -74,8 +71,9 @@ class EventTest extends TestCase
             ->period($dateStarts, $dateEnds)
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('DTSTART', $dateStarts, $payload);
-        $this->assertPropertyEqualsInPayload('DTEND', $dateEnds, $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('DTSTART', $dateStarts)
+            ->expectPropertyValue('DTEND', $dateEnds);
     }
 
     /** @test */
@@ -89,11 +87,13 @@ class EventTest extends TestCase
             ->period($dateStarts, $dateEnds)
             ->resolvePayload();
 
-        $this->assertParameterCountInProperty(1, $payload->getProperty('DTSTART'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
+        PropertyExpectation::create($payload, 'DTSTART')
+            ->expectParameterCount(1)
+            ->expectParameterValue('VALUE', 'DATE');
 
-        $this->assertParameterCountInProperty(1, $payload->getProperty('DTEND'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTEND'));
+        PropertyExpectation::create($payload, 'DTEND')
+            ->expectParameterCount(1)
+            ->expectParameterValue('VALUE', 'DATE');
     }
 
     /** @test */
@@ -107,13 +107,15 @@ class EventTest extends TestCase
             ->period($dateStarts, $dateEnds)
             ->resolvePayload();
 
-        $this->assertParameterCountInProperty(2, $payload->getProperty('DTSTART'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
-        $this->assertParameterEqualsInProperty('TZID', 'Europe/London', $payload->getProperty('DTSTART'));
+        PropertyExpectation::create($payload, 'DTSTART')
+            ->expectParameterCount(2)
+            ->expectParameterValue('VALUE', 'DATE')
+            ->expectParameterValue('TZID', 'Europe/London');
 
-        $this->assertParameterCountInProperty(2, $payload->getProperty('DTEND'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTEND'));
-        $this->assertParameterEqualsInProperty('TZID', 'Europe/London', $payload->getProperty('DTEND'));
+        PropertyExpectation::create($payload, 'DTEND')
+            ->expectParameterCount(2)
+            ->expectParameterValue('VALUE', 'DATE')
+            ->expectParameterValue('TZID', 'Europe/London');
     }
 
     /** @test */
@@ -126,10 +128,13 @@ class EventTest extends TestCase
             ->startsAt($dateStarts)
             ->resolvePayload();
 
-        $this->assertParameterCountInProperty(1, $payload->getProperty('DTSTART'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $payload->getProperty('DTSTART'));
-
-        $this->assertPropertyNotInPayload('DTEND', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyMissing('DTEND')
+            ->expectProperty('DTSTART', function (PropertyExpectation $expectation) {
+                $expectation
+                    ->expectParameterCount(1)
+                    ->expectParameterValue('VALUE', 'DATE');
+            });
     }
 
     /** @test */
@@ -139,10 +144,9 @@ class EventTest extends TestCase
             ->alertMinutesBefore(5)
             ->resolvePayload();
 
-        $subcomponents = $payload->getSubComponents();
-
-        $this->assertCount(1, $subcomponents);
-        $this->assertInstanceOf(Alert::class, $subcomponents[0]);
+        PayloadExpectation::create($payload)
+            ->expectSubComponentCount(1)
+            ->expectSubComponentInstanceOf(0, Alert::class);
     }
 
     /** @test */
@@ -152,10 +156,9 @@ class EventTest extends TestCase
             ->alertMinutesAfter(5)
             ->resolvePayload();
 
-        $subcomponents = $payload->getSubComponents();
-
-        $this->assertCount(1, $subcomponents);
-        $this->assertInstanceOf(Alert::class, $subcomponents[0]);
+        PayloadExpectation::create($payload)
+            ->expectSubComponentCount(1)
+            ->expectSubComponentInstanceOf(0, Alert::class);
     }
 
     /** @test */
@@ -165,10 +168,9 @@ class EventTest extends TestCase
             ->alert(new Alert('Test'))
             ->resolvePayload();
 
-        $subcomponents = $payload->getSubComponents();
-
-        $this->assertCount(1, $subcomponents);
-        $this->assertInstanceOf(Alert::class, $subcomponents[0]);
+        PayloadExpectation::create($payload)
+            ->expectSubComponentCount(1)
+            ->expectSubComponentInstanceOf(0, Alert::class);
     }
 
     /** @test */
@@ -178,10 +180,8 @@ class EventTest extends TestCase
             ->coordinates(51.2343, 4.4287)
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('GEO', [
-            'lat' => 51.2343,
-            'lng' => 4.4287,
-        ], $payload);
+        PropertyExpectation::create($payload, 'GEO')
+            ->expectValue(['lat' => 51.2343, 'lng' => 4.4287]);
     }
 
     /** @test */
@@ -193,19 +193,13 @@ class EventTest extends TestCase
             ->addressName('Spatie HQ')
             ->resolvePayload();
 
-        $this->assertPropertyExistInPayload('X-APPLE-STRUCTURED-LOCATION', $payload);
-
-        $property = $payload->getProperty('X-APPLE-STRUCTURED-LOCATION');
-
-        $this->assertEquals('geo:51.2343,4.4287', $property->getValue());
-        $this->assertEquals([
-            'lat' => 51.2343,
-            'lng' => 4.4287,
-        ], $property->getOriginalValue());
-        $this->assertParameterEqualsInProperty('VALUE', 'URI', $property);
-        $this->assertParameterEqualsInProperty('X-ADDRESS', 'Samberstraat 69D\, 2060 Antwerpen\, Belgium', $property);
-        $this->assertParameterEqualsInProperty('X-APPLE-RADIUS', 72, $property);
-        $this->assertParameterEqualsInProperty('X-TITLE', 'Spatie HQ', $property);
+        PropertyExpectation::create($payload, 'X-APPLE-STRUCTURED-LOCATION')
+            ->expectValue(['lat' => 51.2343, 'lng' => 4.4287,])
+            ->expectOutput('geo:51.2343,4.4287')
+            ->expectParameterValue('VALUE', 'URI')
+            ->expectParameterValue('X-ADDRESS', 'Samberstraat 69D\, 2060 Antwerpen\, Belgium')
+            ->expectParameterValue('X-APPLE-RADIUS', 72)
+            ->expectParameterValue('X-TITLE', 'Spatie HQ');
     }
 
     /** @test */
@@ -215,7 +209,9 @@ class EventTest extends TestCase
             ->classification(Classification::private())
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('CLASS', Classification::private()->value, $payload);
+        PropertyExpectation::create($payload, 'CLASS')
+            ->expectValue(Classification::private()->value)
+            ->expectOutput(Classification::private()->value);
     }
 
     /** @test */
@@ -225,7 +221,8 @@ class EventTest extends TestCase
             ->transparent()
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('TRANSP', 'TRANSPARENT', $payload);
+        PropertyExpectation::create($payload, 'TRANSP')
+            ->expectValue('TRANSPARENT');
     }
 
     /** @test */
@@ -235,11 +232,8 @@ class EventTest extends TestCase
             ->organizer('ruben@spatie.be', 'Ruben')
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload(
-            'ORGANIZER',
-            new CalendarAddress('ruben@spatie.be', 'Ruben'),
-            $payload
-        );
+        PropertyExpectation::create($payload, 'ORGANIZER')
+            ->expectValue(new CalendarAddress('ruben@spatie.be', 'Ruben'));
     }
 
     /** @test */
@@ -249,23 +243,14 @@ class EventTest extends TestCase
             ->attendee('ruben@spatie.be')
             ->attendee('brent@spatie.be', 'Brent')
             ->attendee('adriaan@spatie.be', 'Adriaan', ParticipationStatus::declined())
-            ->resolvePayload()
-            ->getProperties();
+            ->resolvePayload();
 
-        $this->assertContainsEquals(CalendarAddressProperty::create(
+        PayloadExpectation::create($payload)->expectPropertyValue(
             'ATTENDEE',
-            new CalendarAddress('ruben@spatie.be')
-        ), $payload);
-
-        $this->assertContainsEquals(CalendarAddressProperty::create(
-            'ATTENDEE',
-            new CalendarAddress('brent@spatie.be', 'Brent')
-        ), $payload);
-
-        $this->assertContainsEquals(CalendarAddressProperty::create(
-            'ATTENDEE',
+            new CalendarAddress('ruben@spatie.be'),
+            new CalendarAddress('brent@spatie.be', 'Brent'),
             new CalendarAddress('adriaan@spatie.be', 'Adriaan', ParticipationStatus::declined())
-        ), $payload);
+        );
     }
 
     /** @test */
@@ -275,11 +260,8 @@ class EventTest extends TestCase
             ->status(EventStatus::tentative())
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload(
-            'STATUS',
-            EventStatus::tentative()->value,
-            $payload
-        );
+        PropertyExpectation::create($payload, 'STATUS')
+            ->expectValue(EventStatus::tentative()->value);
     }
 
     /** @test */
@@ -294,7 +276,8 @@ class EventTest extends TestCase
             ->address('Antwerp')
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('LOCATION', 'Antwerp', $payload);
+        PropertyExpectation::create($payload, 'LOCATION')
+            ->expectValue('Antwerp');
     }
 
     /** @test */
@@ -304,7 +287,8 @@ class EventTest extends TestCase
             ->rrule($rrule = RRule::frequency(RecurrenceFrequency::daily()))
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('RRULE', $rrule, $payload);
+        PropertyExpectation::create($payload, 'RRULE')
+            ->expectValue($rrule);
     }
 
     /** @test */
@@ -321,15 +305,17 @@ class EventTest extends TestCase
             ->endsAt($dateEnds)
             ->resolvePayload();
 
-        $this->assertParameterCountInProperty(0, $payload->getProperty('DTSTART'));
-        $this->assertParameterCountInProperty(0, $payload->getProperty('DTEND'));
-        $this->assertParameterCountInProperty(0, $payload->getProperty('DTSTAMP'));
+        PropertyExpectation::create($payload, 'DTSTART')->expectParameterCount(0);
+        PropertyExpectation::create($payload, 'DTEND')->expectParameterCount(0);
+        PropertyExpectation::create($payload, 'DTSTAMP')->expectParameterCount(0);
 
-        /** @var \Spatie\IcalendarGenerator\ComponentPayload $alert */
-        $alert = $payload->getSubComponents()[0]->resolvePayload();
-
-        $this->assertParameterCountInProperty(1, $alert->getProperty('TRIGGER'));
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE-TIME', $alert->getProperty('TRIGGER'));
+        PayloadExpectation::create($payload)->expectSubComponent(0, function (PayloadExpectation $expectation) {
+            $expectation->expectProperty('TRIGGER', function (PropertyExpectation $expectation) {
+                $expectation
+                    ->expectParameterCount(1)
+                    ->expectParameterValue('VALUE', 'DATE-TIME');
+            });
+        });
     }
 
     /** @test */
@@ -339,7 +325,8 @@ class EventTest extends TestCase
             ->url('http://example.com/pub/calendars/jsmith/mytime.ics')
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics');
     }
 
     /** @test */
@@ -349,7 +336,8 @@ class EventTest extends TestCase
             ->url('xample.com/pub/calendars/jsmith/mytime.ics')
             ->resolvePayload();
 
-        $this->assertPropertyNotInPayload('URL', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyMissing('URL');
     }
 
     /** @test */
@@ -361,27 +349,22 @@ class EventTest extends TestCase
             ->createdAt($created)
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload(
-            'DTSTAMP',
-            new DateTime('16 may 2020 10:00:00', new DateTimeZone('UTC')),
-            $payload
-        );
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('DTSTAMP', new DateTime('16 may 2020 10:00:00', new DateTimeZone('UTC')));
     }
 
     /** @test */
     public function it_can_add_recurrence_dates()
     {
-        $this->assertBuildPropertyEqualsInPayload(
-            'RDATE',
-            'RDATE;VALUE=DATE-TIME:20200516T120000Z',
-            Event::create()->repeatOn(new DateTime('16 may 2020 12:00:00'))->resolvePayload()
-        );
+        PropertyExpectation::create(
+            Event::create()->repeatOn(new DateTime('16 may 2020 12:00:00'))->resolvePayload(),
+            'RDATE'
+        )->expectBuilt('RDATE;VALUE=DATE-TIME:20200516T120000Z');
 
-        $this->assertBuildPropertyEqualsInPayload(
-            'RDATE',
-            'RDATE;VALUE=DATE:20200516',
-            Event::create()->repeatOn(new DateTime('16 may 2020 12:00:00'), false)->resolvePayload()
-        );
+        PropertyExpectation::create(
+            Event::create()->repeatOn(new DateTime('16 may 2020 12:00:00'), false)->resolvePayload(),
+            'RDATE'
+        )->expectBuilt('RDATE;VALUE=DATE:20200516');
     }
 
     /** @test */
@@ -393,49 +376,57 @@ class EventTest extends TestCase
         $dateC = new DateTime('13 august 2019 12:00:00');
         $dateD = new DateTime('13 august 2020 15:00:00');
 
-        $properties = Event::create()
+        $payload = Event::create()
             ->repeatOn([$dateA, $dateB])
             ->repeatOn([$dateC, $dateD], false)
-            ->resolvePayload()
-            ->getProperties();
+            ->resolvePayload();
 
-        $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateA, true))
-                ->addParameter(Parameter::create('VALUE', 'DATE-TIME')),
-            $properties
-        );
-
-        $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateB, true))
-                ->addParameter(Parameter::create('VALUE', 'DATE-TIME')),
-            $properties
-        );
-
-        $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateC, false)),
-            $properties
-        );
-
-        $this->assertContainsEquals(
-            DateTimeProperty::create('RDATE', DateTimeValue::create($dateD, false)),
-            $properties
-        );
+        PayloadExpectation::create($payload)
+            ->expectProperty(
+                'RDATE',
+                function (PropertyExpectation $expectation) use ($dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateA)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE-TIME');
+                },
+                function (PropertyExpectation $expectation) use ($dateB, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateB)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE-TIME');
+                },
+                function (PropertyExpectation $expectation) use ($dateC, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateC)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE');
+                },
+                function (PropertyExpectation $expectation) use ($dateD, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateD)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE');
+                }
+            );
     }
 
     /** @test */
     public function it_can_add_excluded_recurrence_dates()
     {
-        $this->assertBuildPropertyEqualsInPayload(
-            'EXDATE',
-            'EXDATE;VALUE=DATE-TIME:20200516T120000Z',
-            Event::create()->doNotRepeatOn(new DateTime('16 may 2020 12:00:00'))->resolvePayload()
-        );
+        PropertyExpectation::create(
+            Event::create()->doNotRepeatOn(new DateTime('16 may 2020 12:00:00'))->resolvePayload(),
+            'EXDATE'
+        )->expectBuilt('EXDATE;VALUE=DATE-TIME:20200516T120000Z');
 
-        $this->assertBuildPropertyEqualsInPayload(
-            'EXDATE',
-            'EXDATE;VALUE=DATE:20200516',
-            Event::create()->doNotRepeatOn(new DateTime('16 may 2020 12:00:00'), false)->resolvePayload()
-        );
+        PropertyExpectation::create(
+            Event::create()->doNotRepeatOn(new DateTime('16 may 2020 12:00:00'), false)->resolvePayload(),
+            'EXDATE'
+        )->expectBuilt('EXDATE;VALUE=DATE:20200516');
     }
 
     /** @test */
@@ -447,32 +438,70 @@ class EventTest extends TestCase
         $dateC = new DateTime('13 august 2019 12:00:00');
         $dateD = new DateTime('13 august 2020 15:00:00');
 
-        $properties = Event::create()
+        $payload = Event::create()
             ->doNotRepeatOn([$dateA, $dateB])
             ->doNotRepeatOn([$dateC, $dateD], false)
-            ->resolvePayload()
-            ->getProperties();
+            ->resolvePayload();
 
-        $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateA, true))
-                ->addParameter(Parameter::create('VALUE', 'DATE-TIME')),
-            $properties
-        );
+        PayloadExpectation::create($payload)
+            ->expectProperty(
+                'EXDATE',
+                function (PropertyExpectation $expectation) use ($dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateA)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE-TIME');
+                },
+                function (PropertyExpectation $expectation) use ($dateB, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateB)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE-TIME');
+                },
+                function (PropertyExpectation $expectation) use ($dateC, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateC)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE');
+                },
+                function (PropertyExpectation $expectation) use ($dateD, $dateA) {
+                    $expectation
+                        ->expectInstanceOf(DateTimeProperty::class)
+                        ->expectValue($dateD)
+                        ->expectParameterCount(1)
+                        ->expectParameterValue('VALUE', 'DATE');
+                }
+            );
+    }
 
-        $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateB, true))
-                ->addParameter(Parameter::create('VALUE', 'DATE-TIME')),
-            $properties
-        );
+    /** @test */
+    public function it_can_add_an_attachment_to_an_event()
+    {
+        $payload = Event::create()
+            ->attachment('http://spatie.be/logo.svg')
+            ->resolvePayload();
 
-        $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateC, false)),
-            $properties
-        );
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('ATTACH', 'http://spatie.be/logo.svg');
+    }
 
-        $this->assertContainsEquals(
-            DateTimeProperty::create('EXDATE', DateTimeValue::create($dateD, false)),
-            $properties
-        );
+    /** @test */
+    public function it_can_add_multiple_attachment_to_an_event()
+    {
+        $payload = Event::create()
+            ->attachment('http://spatie.be/logo.svg', 'http://spatie.be/logo.png')
+            ->attachment('http://spatie.be/logo.jpg')
+            ->resolvePayload();
+
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue(
+                'ATTACH',
+                'http://spatie.be/logo.svg',
+                'http://spatie.be/logo.png',
+                'http://spatie.be/logo.jpg'
+            );
     }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -487,10 +487,10 @@ class EventTest extends TestCase
 
         PayloadExpectation::create($payload)->expectProperty(
             'ATTACH',
-            fn(PropertyExpectation $expectation) => $expectation
+            fn (PropertyExpectation $expectation) => $expectation
                 ->expectParameterCount(0)
                 ->expectValue('http://spatie.be/logo.svg'),
-            fn(PropertyExpectation $expectation) => $expectation
+            fn (PropertyExpectation $expectation) => $expectation
                 ->expectParameterCount(1)
                 ->expectParameterValue('FMTTYPE', 'application/html')
                 ->expectValue('http://spatie.be/logo.jpg'),

--- a/tests/Components/TimezoneEntryTest.php
+++ b/tests/Components/TimezoneEntryTest.php
@@ -7,6 +7,7 @@ use Spatie\IcalendarGenerator\Builders\ComponentBuilder;
 use Spatie\IcalendarGenerator\Components\TimezoneEntry;
 use Spatie\IcalendarGenerator\Enums\RecurrenceFrequency;
 use Spatie\IcalendarGenerator\Enums\TimezoneEntryType;
+use Spatie\IcalendarGenerator\Tests\PayloadExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\ValueObjects\RRule;
 
@@ -22,10 +23,11 @@ class TimezoneEntryTest extends TestCase
             '+02:00'
         )->resolvePayload();
 
-        $this->assertEquals('STANDARD', $payload->getType());
-        $this->assertPropertyEqualsInPayload('DTSTART', new DateTime('16 may 2020 12:00:00'), $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETFROM', '+00:00', $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETTO', '+02:00', $payload);
+        PayloadExpectation::create($payload)
+            ->expectType('STANDARD')
+            ->expectPropertyValue('DTSTART', new DateTime('16 may 2020 12:00:00'))
+            ->expectPropertyValue('TZOFFSETFROM', '+00:00')
+            ->expectPropertyValue('TZOFFSETTO', '+02:00');
     }
 
     /** @test */
@@ -38,10 +40,11 @@ class TimezoneEntryTest extends TestCase
             '-02:00'
         )->resolvePayload();
 
-        $this->assertEquals('STANDARD', $payload->getType());
-        $this->assertPropertyEqualsInPayload('DTSTART', new DateTime('16 may 2020 12:00:00'), $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETFROM', '-00:00', $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETTO', '-02:00', $payload);
+        PayloadExpectation::create($payload)
+            ->expectType('STANDARD')
+            ->expectPropertyValue('DTSTART', new DateTime('16 may 2020 12:00:00'))
+            ->expectPropertyValue('TZOFFSETFROM', '-00:00')
+            ->expectPropertyValue('TZOFFSETTO', '-02:00');
     }
 
     /** @test */
@@ -54,10 +57,11 @@ class TimezoneEntryTest extends TestCase
             '+02:00'
         )->resolvePayload();
 
-        $this->assertEquals('DAYLIGHT', $payload->getType());
-        $this->assertPropertyEqualsInPayload('DTSTART', new DateTime('16 may 2020 12:00:00'), $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETFROM', '+00:00', $payload);
-        $this->assertPropertyEqualsInPayload('TZOFFSETTO', '+02:00', $payload);
+        PayloadExpectation::create($payload)
+            ->expectType('DAYLIGHT')
+            ->expectPropertyValue('DTSTART', new DateTime('16 may 2020 12:00:00'))
+            ->expectPropertyValue('TZOFFSETFROM', '+00:00')
+            ->expectPropertyValue('TZOFFSETTO', '+02:00');
     }
 
     /** @test */
@@ -73,8 +77,9 @@ class TimezoneEntryTest extends TestCase
             ->description('Belgian timezones ftw!')
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('TZNAME', 'Europe - Brussels', $payload);
-        $this->assertPropertyEqualsInPayload('COMMENT', 'Belgian timezones ftw!', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('TZNAME', 'Europe - Brussels')
+            ->expectPropertyValue('COMMENT', 'Belgian timezones ftw!');
     }
 
     /** @test */
@@ -89,7 +94,8 @@ class TimezoneEntryTest extends TestCase
             ->rrule(RRule::frequency(RecurrenceFrequency::daily()))
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('RRULE', RRule::frequency(RecurrenceFrequency::daily()), $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('RRULE', RRule::frequency(RecurrenceFrequency::daily()));
     }
 
     /** @test */

--- a/tests/Components/TimezoneTest.php
+++ b/tests/Components/TimezoneTest.php
@@ -8,6 +8,7 @@ use Spatie\IcalendarGenerator\Builders\ComponentBuilder;
 use Spatie\IcalendarGenerator\Components\Timezone;
 use Spatie\IcalendarGenerator\Components\TimezoneEntry;
 use Spatie\IcalendarGenerator\Enums\TimezoneEntryType;
+use Spatie\IcalendarGenerator\Tests\PayloadExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class TimezoneTest extends TestCase
@@ -17,7 +18,8 @@ class TimezoneTest extends TestCase
     {
         $payload = Timezone::create('Europe/Brussels')->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('TZID', 'Europe/Brussels', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('TZID', 'Europe/Brussels');
     }
 
     /** @test */
@@ -27,11 +29,8 @@ class TimezoneTest extends TestCase
             ->lastModified(new DateTime('16 may 2020 12:00:00', new DateTimeZone('Europe/Brussels')))
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload(
-            'LAST-MODIFIED',
-            new DateTime('16 may 2020 10:00:00', new DateTimeZone('UTC')),
-            $payload
-        );
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('LAST-MODIFIED', new DateTime('16 may 2020 10:00:00', new DateTimeZone('UTC')));
     }
 
     /** @test */
@@ -41,7 +40,8 @@ class TimezoneTest extends TestCase
             ->url('https://spatie.be')
             ->resolvePayload();
 
-        $this->assertPropertyEqualsInPayload('TZURL', 'https://spatie.be', $payload);
+        PayloadExpectation::create($payload)
+            ->expectPropertyValue('TZURL', 'https://spatie.be');
     }
 
     /** @test */
@@ -54,7 +54,7 @@ class TimezoneTest extends TestCase
             ->entry($this->createTimezoneEntry())
             ->resolvePayload();
 
-        $this->assertCount(4, $payload->getSubComponents());
+        PayloadExpectation::create($payload)->expectSubComponentCount(4);
     }
 
     /** @test */

--- a/tests/PayloadExpectation.php
+++ b/tests/PayloadExpectation.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Spatie\IcalendarGenerator\Tests;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+use Spatie\IcalendarGenerator\ComponentPayload;
+use Spatie\IcalendarGenerator\Components\Component;
+use Spatie\IcalendarGenerator\Properties\Property;
+
+class PayloadExpectation
+{
+    private ComponentPayload $payload;
+
+    public static function create(ComponentPayload $payload): self
+    {
+        return new self($payload);
+    }
+
+    public function __construct(ComponentPayload $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function expectType(string $type): self
+    {
+        Assert::assertEquals($type, $this->payload->getType());
+
+        return $this;
+    }
+
+    public function expectPropertyCount(int $count): self
+    {
+        Assert::assertCount($count, $this->payload->getProperties());
+
+        return $this;
+    }
+
+    public function expectProperty(string $name, Closure  ...$closures): self
+    {
+        $properties = $this->getProperties($name);
+
+        foreach ($closures as $index => $closure) {
+            ($closure)(PropertyExpectation::create($properties[$index]));
+        }
+
+        return $this;
+    }
+
+    public function expectPropertyValue(string $name, ...$values): self
+    {
+        $propertyValues = array_map(function (Property $property) {
+            return $property->getOriginalValue();
+        }, $this->getProperties($name));
+
+        foreach ($values as $value) {
+            if (in_array($value, $propertyValues)) {
+                Assert::assertTrue(true);
+            } else {
+                Assert::assertTrue(false, "Could not find property with name: {$name} and value: {$value}");
+            }
+        }
+
+        return $this;
+    }
+
+    public function expectPropertyExists(string $name): self
+    {
+        Assert::assertNotEmpty($this->getProperties($name));
+
+        return $this;
+    }
+
+    public function expectPropertyMissing(string $name): self
+    {
+        Assert::assertObjectNotHasAttribute($name, $this->payload);
+
+        return $this;
+    }
+
+    public function expectSubComponentCount(int $count): self
+    {
+        Assert::assertCount($count, $this->payload->getSubComponents());
+
+        return $this;
+    }
+
+    public function expectSubComponents(Component ...$component): self
+    {
+        Assert::assertEqualsCanonicalizing($component, $this->payload->getSubComponents());
+
+        return $this;
+    }
+
+    public function expectSubComponent(int $index, Closure $closure): self
+    {
+        /** @var \Spatie\IcalendarGenerator\Components\Component $subcomponent */
+        $subcomponent = $this->payload->getSubComponents()[$index];
+
+        $closure(PayloadExpectation::create($subcomponent->resolvePayload()));
+
+        return $this;
+    }
+
+    public function expectSubComponentInstanceOf(int $index, string $class): self
+    {
+        /** @var \Spatie\IcalendarGenerator\Components\Component $subcomponent */
+        $subcomponent = $this->payload->getSubComponents()[$index];
+
+        Assert::assertInstanceOf($class, $subcomponent);
+
+        return $this;
+    }
+
+    public function expectSubComponentNotInstanceOf(int $index, string $class): self
+    {
+        /** @var \Spatie\IcalendarGenerator\Components\Component $subcomponent */
+        $subcomponent = $this->payload->getSubComponents()[$index];
+
+        Assert::assertNotInstanceOf($class, $subcomponent);
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \Spatie\IcalendarGenerator\Properties\Property[]
+     * @throws \Exception
+     */
+    private function getProperties(string $name): array
+    {
+        $filteredProperties = array_filter(
+            $this->payload->getProperties(),
+            function (Property $property) use ($name) {
+                return in_array($name, $property->getNameAndAliases());
+            }
+        );
+
+        return array_values($filteredProperties);
+    }
+}

--- a/tests/Properties/AppleLocationCoordinatesPropertyTest.php
+++ b/tests/Properties/AppleLocationCoordinatesPropertyTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Properties\AppleLocationCoordinatesProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class AppleLocationCoordinatesPropertyTest extends TestCase
@@ -12,15 +13,13 @@ class AppleLocationCoordinatesPropertyTest extends TestCase
     {
         $propertyType = new AppleLocationCoordinatesProperty(10.5, 20.5, 'Samberstraat 69D, 2060 Antwerpen, Belgium', 'Spatie HQ', 72);
 
-        $this->assertEquals('X-APPLE-STRUCTURED-LOCATION', $propertyType->getName());
-        $this->assertEquals('geo:10.5,20.5', $propertyType->getValue());
-        $this->assertEquals('URI', $propertyType->getParameter('VALUE')->getValue());
-        $this->assertEquals('Samberstraat 69D\, 2060 Antwerpen\, Belgium', $propertyType->getParameter('X-ADDRESS')->getValue());
-        $this->assertEquals('Spatie HQ', $propertyType->getParameter('X-TITLE')->getValue());
-        $this->assertEquals(72, $propertyType->getParameter('X-APPLE-RADIUS')->getValue());
-        $this->assertEquals([
-            'lat' => 10.5,
-            'lng' => 20.5,
-        ], $propertyType->getOriginalValue());
+        PropertyExpectation::create($propertyType)
+            ->expectName('X-APPLE-STRUCTURED-LOCATION')
+            ->expectValue(['lat' => 10.5, 'lng' => 20.5,])
+            ->expectOutput('geo:10.5,20.5')
+            ->expectParameterValue('VALUE', 'URI')
+            ->expectParameterValue('X-ADDRESS', 'Samberstraat 69D\, 2060 Antwerpen\, Belgium')
+            ->expectParameterValue('X-TITLE', 'Spatie HQ')
+            ->expectParameterValue('X-APPLE-RADIUS', 72);
     }
 }

--- a/tests/Properties/CalendarAddressPropertyTest.php
+++ b/tests/Properties/CalendarAddressPropertyTest.php
@@ -4,6 +4,7 @@ namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Enums\ParticipationStatus;
 use Spatie\IcalendarGenerator\Properties\CalendarAddressProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\ValueObjects\CalendarAddress;
 
@@ -17,10 +18,10 @@ class CalendarAddressPropertyTest extends TestCase
             new CalendarAddress('ruben@spatie.be')
         );
 
-        $this->assertEquals('ORGANIZER', $property->getName());
-        $this->assertEquals('MAILTO:ruben@spatie.be', $property->getValue());
-
-        $this->assertParameterCountInProperty(0, $property);
+        PropertyExpectation::create($property)
+            ->expectName('ORGANIZER')
+            ->expectOutput('MAILTO:ruben@spatie.be')
+            ->expectParameterCount(0);
     }
 
     /** @test */
@@ -31,11 +32,11 @@ class CalendarAddressPropertyTest extends TestCase
             new CalendarAddress('ruben@spatie.be', 'Ruben', ParticipationStatus::accepted())
         );
 
-        $this->assertEquals('ORGANIZER', $property->getName());
-        $this->assertEquals('MAILTO:ruben@spatie.be', $property->getValue());
-
-        $this->assertParameterCountInProperty(2, $property);
-        $this->assertParameterEqualsInProperty('CN', 'Ruben', $property);
-        $this->assertParameterEqualsInProperty('PARTSTAT', ParticipationStatus::accepted()->value, $property);
+        PropertyExpectation::create($property)
+            ->expectName('ORGANIZER')
+            ->expectOutput('MAILTO:ruben@spatie.be')
+            ->expectParameterCount(2)
+            ->expectParameterValue('CN', 'Ruben')
+            ->expectParameterValue('PARTSTAT', ParticipationStatus::accepted()->value);
     }
 }

--- a/tests/Properties/CoordinatesPropertyTest.php
+++ b/tests/Properties/CoordinatesPropertyTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Properties\CoordinatesProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class CoordinatesPropertyTest extends TestCase
@@ -12,11 +13,9 @@ class CoordinatesPropertyTest extends TestCase
     {
         $propertyType = new CoordinatesProperty('GEO', 10.5, 20.5);
 
-        $this->assertEquals('GEO', $propertyType->getName());
-        $this->assertEquals('10.5;20.5', $propertyType->getValue());
-        $this->assertEquals([
-            'lat' => 10.5,
-            'lng' => 20.5,
-        ], $propertyType->getOriginalValue());
+        PropertyExpectation::create($propertyType)
+            ->expectName('GEO')
+            ->expectOutput('10.5;20.5')
+            ->expectValue(['lat' => 10.5, 'lng' => 20.5]);
     }
 }

--- a/tests/Properties/DateTimePropertyTest.php
+++ b/tests/Properties/DateTimePropertyTest.php
@@ -5,6 +5,7 @@ namespace Spatie\IcalendarGenerator\Tests\Properties;
 use DateTime;
 use DateTimeZone;
 use Spatie\IcalendarGenerator\Properties\DateTimeProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\ValueObjects\DateTimeValue;
 
@@ -24,7 +25,7 @@ class DateTimePropertyTest extends TestCase
     {
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date);
 
-        $this->assertEquals('20190516', $property->getValue());
+        PropertyExpectation::create($property)->expectOutput('20190516');
     }
 
     /** @test */
@@ -32,9 +33,10 @@ class DateTimePropertyTest extends TestCase
     {
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, true);
 
-        $this->assertEquals('20190516T121015', $property->getValue());
-        $this->assertCount(1, $property->getParameters());
-        $this->assertParameterEqualsInProperty('TZID', 'Europe/Brussels', $property);
+        PropertyExpectation::create($property)
+            ->expectOutput('20190516T121015')
+            ->expectParameterCount(1)
+            ->expectParameterValue('TZID', 'Europe/Brussels');
     }
 
     /** @test */
@@ -44,8 +46,9 @@ class DateTimePropertyTest extends TestCase
 
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, true);
 
-        $this->assertEquals('20190516T101015Z', $property->getValue());
-        $this->assertCount(0, $property->getParameters());
+        PropertyExpectation::create($property)
+            ->expectOutput('20190516T101015Z')
+            ->expectParameterCount(0);
     }
 
     /** @test */
@@ -55,9 +58,10 @@ class DateTimePropertyTest extends TestCase
 
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date);
 
-        $this->assertEquals('20190516', $property->getValue());
-        $this->assertParameterCountInProperty(1, $property);
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $property);
+        PropertyExpectation::create($property)
+            ->expectOutput('20190516')
+            ->expectParameterCount(1)
+            ->expectParameterValue('VALUE', 'DATE');
     }
 
     /** @test */
@@ -65,10 +69,11 @@ class DateTimePropertyTest extends TestCase
     {
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, false);
 
-        $this->assertEquals('20190516', $property->getValue());
-        $this->assertCount(2, $property->getParameters());
-        $this->assertParameterEqualsInProperty('TZID', 'Europe/Brussels', $property);
-        $this->assertParameterEqualsInProperty('VALUE', 'DATE', $property);
+        PropertyExpectation::create($property)
+            ->expectOutput('20190516')
+            ->expectParameterCount(2)
+            ->expectParameterValue('TZID', 'Europe/Brussels')
+            ->expectParameterValue('VALUE', 'DATE');
     }
 
     /** @test */
@@ -78,9 +83,10 @@ class DateTimePropertyTest extends TestCase
 
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, true);
 
-        $this->assertEquals('20190516T121015', $property->getValue());
-        $this->assertCount(1, $property->getParameters());
-        $this->assertParameterEqualsInProperty('TZID', 'Europe/Brussels', $property);
+        PropertyExpectation::create($property)
+            ->expectOutput('20190516T121015')
+            ->expectParameterCount(1)
+            ->expectParameterValue('TZID', 'Europe/Brussels');
     }
 
     /** @test */
@@ -88,7 +94,7 @@ class DateTimePropertyTest extends TestCase
     {
         $property = DateTimeProperty::fromDateTime('STARTS', $this->date, true, true);
 
-        $this->assertEquals('20190516T121015', $property->getValue());
+        PropertyExpectation::create($property)->expectOutput('20190516T121015');
     }
 
     /** @test */
@@ -99,6 +105,6 @@ class DateTimePropertyTest extends TestCase
             DateTimeValue::create($this->date)
         );
 
-        $this->assertEquals('20190516T121015', $property->getValue());
+        PropertyExpectation::create($property)->expectOutput('20190516T121015');
     }
 }

--- a/tests/Properties/DurationPropertyTest.php
+++ b/tests/Properties/DurationPropertyTest.php
@@ -4,6 +4,7 @@ namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use DateInterval;
 use Spatie\IcalendarGenerator\Properties\DurationProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class DurationPropertyTest extends TestCase
@@ -15,8 +16,9 @@ class DurationPropertyTest extends TestCase
 
         $property = new DurationProperty('DURATION', $interval);
 
-        $this->assertEquals('DURATION', $property->getName());
-        $this->assertEquals($interval, $property->getOriginalValue());
-        $this->assertEquals('PT5M', $property->getValue());
+        PropertyExpectation::create($property)
+            ->expectName('DURATION')
+            ->expectValue($interval)
+            ->expectOutput('PT5M');
     }
 }

--- a/tests/Properties/EmptyPropertyTest.php
+++ b/tests/Properties/EmptyPropertyTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Properties\EmptyProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class EmptyPropertyTest extends TestCase
@@ -15,5 +16,10 @@ class EmptyPropertyTest extends TestCase
         $this->assertEquals('CONTACT', $propertyType->getName());
         $this->assertEquals(null, $propertyType->getValue());
         $this->assertEquals(null, $propertyType->getOriginalValue());
+
+        PropertyExpectation::create($propertyType)
+            ->expectName('CONTACT')
+            ->expectValue(null)
+            ->expectOutput(null);
     }
 }

--- a/tests/Properties/RRulePropertyTest.php
+++ b/tests/Properties/RRulePropertyTest.php
@@ -4,6 +4,7 @@ namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Enums\RecurrenceFrequency;
 use Spatie\IcalendarGenerator\Properties\RRuleProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 use Spatie\IcalendarGenerator\ValueObjects\RRule;
 
@@ -16,8 +17,9 @@ class RRulePropertyTest extends TestCase
 
         $propertyType = RRuleProperty::create('RRULE', $recurrenceRule);
 
-        $this->assertEquals('RRULE', $propertyType->getName());
-        $this->assertEquals('FREQ=DAILY', $propertyType->getValue());
-        $this->assertEquals($recurrenceRule, $propertyType->getOriginalValue());
+        PropertyExpectation::create($propertyType)
+            ->expectName('RRULE')
+            ->expectOutput('FREQ=DAILY')
+            ->expectValue($recurrenceRule);
     }
 }

--- a/tests/Properties/TextPropertyTest.php
+++ b/tests/Properties/TextPropertyTest.php
@@ -4,6 +4,7 @@ namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Enums\Classification;
 use Spatie\IcalendarGenerator\Properties\TextProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class TextPropertyTest extends TestCase
@@ -71,6 +72,8 @@ class TextPropertyTest extends TestCase
     {
         $property = TextProperty::createFromEnum('', Classification::private());
 
-        $this->assertEquals('PRIVATE', $property->getValue());
+        PropertyExpectation::create($property)
+            ->expectOutput('PRIVATE')
+            ->expectValue('PRIVATE');
     }
 }

--- a/tests/Properties/UriPropertyTest.php
+++ b/tests/Properties/UriPropertyTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\IcalendarGenerator\Tests\Properties;
 
 use Spatie\IcalendarGenerator\Properties\UriProperty;
+use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 use Spatie\IcalendarGenerator\Tests\TestCase;
 
 class UriPropertyTest extends TestCase
@@ -10,22 +11,16 @@ class UriPropertyTest extends TestCase
     /** @test */
     public function it_accepts_an_uri()
     {
-        $this->assertEquals(
-            'http://this.is/a/valid/uri',
-            (new UriProperty('', 'http://this.is/a/valid/uri'))->getValue()
-        );
+        PropertyExpectation::create(new UriProperty('', 'http://this.is/a/valid/uri'))
+            ->expectValue('http://this.is/a/valid/uri');
 
-        $this->assertEquals(
-            'foo://example.com:8042/over/there?name=ferret#nose',
-            (new UriProperty('', 'foo://example.com:8042/over/there?name=ferret#nose'))->getValue()
-        );
+        PropertyExpectation::create(new UriProperty('', 'foo://example.com:8042/over/there?name=ferret#nose'))
+            ->expectValue('foo://example.com:8042/over/there?name=ferret#nose');
     }
 
     /** @test */
     public function it_will_return_an_empty_string_if_the_uri_is_not_valid()
     {
-        $this->assertEmpty(
-            (new UriProperty('', 'i-am-not-valid'))->getValue()
-        );
+        PropertyExpectation::create(new UriProperty('', 'i-am-not-valid'))->expectOutput('');
     }
 }

--- a/tests/PropertyExpectation.php
+++ b/tests/PropertyExpectation.php
@@ -17,7 +17,7 @@ class PropertyExpectation
      */
     public static function create($instance, string $name = null): self
     {
-        if($instance instanceof Property){
+        if ($instance instanceof Property) {
             return new self($instance);
         }
 

--- a/tests/PropertyExpectation.php
+++ b/tests/PropertyExpectation.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Spatie\IcalendarGenerator\Tests;
+
+use PHPUnit\Framework\Assert;
+use Spatie\IcalendarGenerator\Builders\PropertyBuilder;
+use Spatie\IcalendarGenerator\Properties\Property;
+
+class PropertyExpectation
+{
+    private Property $property;
+
+    /**
+     * @param \Spatie\IcalendarGenerator\Properties\Property|\Spatie\IcalendarGenerator\ComponentPayload $instance
+     *
+     * @return static
+     */
+    public static function create($instance, string $name = null): self
+    {
+        if($instance instanceof Property){
+            return new self($instance);
+        }
+
+        return new self($instance->getProperty($name));
+    }
+
+    public function __construct(Property $property)
+    {
+        $this->property = $property;
+    }
+
+    public function expectInstanceOf(string $class): self
+    {
+        Assert::assertInstanceOf($class, $this->property);
+
+        return $this;
+    }
+
+    public function expectName(string $name): self
+    {
+        Assert::assertEquals($name, $this->property->getName());
+
+        return $this;
+    }
+
+    public function expectValue($value): self
+    {
+        Assert::assertEquals($value, $this->property->getOriginalValue());
+
+        return $this;
+    }
+
+    public function expectOutput($output): self
+    {
+        Assert::assertEquals($output, $this->property->getValue());
+
+        return $this;
+    }
+
+    public function expectBuilt($built): self
+    {
+        Assert::assertEquals($built, (new PropertyBuilder($this->property))->build()[0]);
+
+        return $this;
+    }
+
+    public function expectParameterCount(int $count): self
+    {
+        Assert::assertCount(
+            $count,
+            $this->property->getParameters(),
+            "Failed asserting that actual size ".count($this->property->getParameters())." matches expected size {$count}. Parameters: ". json_encode($this->property->getParameters())
+        );
+
+        return $this;
+    }
+
+    public function expectParameterValue(string $name, $value)
+    {
+        Assert::assertEquals($value, $this->property->getParameter($name)->getValue());
+
+        return $this;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,6 @@
 namespace Spatie\IcalendarGenerator\Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
-use Spatie\IcalendarGenerator\Builders\PropertyBuilder;
-use Spatie\IcalendarGenerator\ComponentPayload;
-use Spatie\IcalendarGenerator\Properties\Property;
 use Spatie\Snapshots\MatchesSnapshots;
 
 abstract class TestCase extends BaseTestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,36 +11,4 @@ use Spatie\Snapshots\MatchesSnapshots;
 abstract class TestCase extends BaseTestCase
 {
     use MatchesSnapshots;
-
-    protected function assertPropertyExistInPayload(string $name, ComponentPayload $componentPayload): void
-    {
-        $this->assertNotNull($componentPayload->getProperty($name));
-    }
-
-    protected function assertPropertyNotInPayload(string $name, ComponentPayload $componentPayload): void
-    {
-        $this->assertObjectNotHasAttribute($name, $componentPayload);
-    }
-
-    protected function assertPropertyEqualsInPayload(string $name, $value, ComponentPayload $componentPayload): void
-    {
-        $this->assertEquals($value, $componentPayload->getProperty($name)->getOriginalValue());
-    }
-
-    protected function assertParameterEqualsInProperty(string $name, $value, Property $propertyType): void
-    {
-        $this->assertEquals($value, $propertyType->getParameter($name)->getValue());
-    }
-
-    protected function assertParameterCountInProperty(int $count, Property $propertyType): void
-    {
-        $this->assertCount($count, $propertyType->getParameters());
-    }
-
-    protected function assertBuildPropertyEqualsInPayload(string $name, string $value, ComponentPayload $componentPayload)
-    {
-        $buildValue = (new PropertyBuilder($componentPayload->getProperty($name)))->build()[0];
-
-        $this->assertEquals($value, $buildValue);
-    }
 }


### PR DESCRIPTION
- Adds a `PayloadExpectation` and `PropertyExpectation` class that can be used to test objects
- At the moment the `Expectation` classes live within the `src` directory, because we could extend them with more meaningful methods like `expectName('An Event')` so it can also be used by people using the package. Not only for the package tests
- Started all of this with adding the `ATTACH` property to the package

TODO:
- First the names of the `Expectation` class methods started with `expect`, I removed that but not entirely sure if that's the way to go
- Some signatures and impementations of the `Expectation` classes can be better
- Do we need a `SubComponentExpecation` class?