### PR TITLE
Ability to require attendees to RSVP to the event (Make Installed Outlook play nice with RSVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ There are five participation statuses:
 - `ParticipationStatus::needs_action()`
 - `ParticipationStatus::delegated()`
 
+
+You can indicate that an attendee is required to RSVP to an event:
+
+``` php
+Event::create()
+    ->attendee('ruben@spatie.be', 'Ruben', ParticipationStatus::needs_action(), true) //true as the fourth parameter
+    ...
+```
+
 An event can be made transparent, so it does not overlap visually with other events in a calendar:
 
 ``` php

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -241,9 +241,10 @@ class Event extends Component implements HasTimezones
     public function attendee(
         string $email,
         string $name = null,
-        ParticipationStatus $participationStatus = null
+        ParticipationStatus $participationStatus = null,
+        bool $requiresResponse = false
     ): Event {
-        $this->attendees[] = new CalendarAddress($email, $name, $participationStatus);
+        $this->attendees[] = new CalendarAddress($email, $name, $participationStatus, $requiresResponse);
 
         return $this;
     }

--- a/src/Properties/CalendarAddressProperty.php
+++ b/src/Properties/CalendarAddressProperty.php
@@ -23,7 +23,7 @@ class CalendarAddressProperty extends Property
         }
 
         if($this->calendarAddress->requiresResponse) {
-            $this->addParameter(Parameter::create('RSVP', "TRUE"));
+            $this->addParameter(Parameter::create('RSVP', 'TRUE'));
         }
 
         if ($this->calendarAddress->participationStatus) {

--- a/src/Properties/CalendarAddressProperty.php
+++ b/src/Properties/CalendarAddressProperty.php
@@ -22,6 +22,10 @@ class CalendarAddressProperty extends Property
             $this->addParameter(Parameter::create('CN', $this->calendarAddress->name));
         }
 
+        if($this->calendarAddress->requiresResponse) {
+            $this->addParameter(Parameter::create('RSVP', "TRUE"));
+        }
+
         if ($this->calendarAddress->participationStatus) {
             $this->addParameter(
                 Parameter::create('PARTSTAT', (string) $this->calendarAddress->participationStatus)

--- a/src/ValueObjects/CalendarAddress.php
+++ b/src/ValueObjects/CalendarAddress.php
@@ -11,15 +11,19 @@ class CalendarAddress
 
     public ?string $name = null;
 
+    public bool $requiresResponse = false;
+
     public ?ParticipationStatus $participationStatus = null;
 
     public function __construct(
         string $email,
         string $name = null,
-        ParticipationStatus $participationStatus = null
+        ParticipationStatus $participationStatus = null,
+        bool $requiresResponse = false
     ) {
         $this->email = $email;
         $this->name = $name;
         $this->participationStatus = $participationStatus;
+        $this->requiresResponse = $requiresResponse;
     }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -243,13 +243,15 @@ class EventTest extends TestCase
             ->attendee('ruben@spatie.be')
             ->attendee('brent@spatie.be', 'Brent')
             ->attendee('adriaan@spatie.be', 'Adriaan', ParticipationStatus::declined())
+            ->attendee('john@spatie.be', 'John', ParticipationStatus::needs_action(), true)
             ->resolvePayload();
 
         PayloadExpectation::create($payload)->expectPropertyValue(
             'ATTENDEE',
             new CalendarAddress('ruben@spatie.be'),
             new CalendarAddress('brent@spatie.be', 'Brent'),
-            new CalendarAddress('adriaan@spatie.be', 'Adriaan', ParticipationStatus::declined())
+            new CalendarAddress('adriaan@spatie.be', 'Adriaan', ParticipationStatus::declined()),
+            new CalendarAddress('john@spatie.be', 'John', ParticipationStatus::needs_action(), true)
         );
     }
 

--- a/tests/Properties/CalendarAddressPropertyTest.php
+++ b/tests/Properties/CalendarAddressPropertyTest.php
@@ -39,4 +39,21 @@ class CalendarAddressPropertyTest extends TestCase
             ->expectParameterValue('CN', 'Ruben')
             ->expectParameterValue('PARTSTAT', ParticipationStatus::accepted()->value);
     }
+
+     /** @test */
+     public function it_can_set_rsvp_to_true()
+    {
+        $property = new CalendarAddressProperty(
+            'ATTENDEE',
+            new CalendarAddress('ruben@spatie.be', 'Ruben', ParticipationStatus::needs_action(), true)
+        );
+
+        PropertyExpectation::create($property)
+            ->expectName('ATTENDEE')
+            ->expectOutput('MAILTO:ruben@spatie.be')
+            ->expectParameterCount(3)
+            ->expectParameterValue('CN', 'Ruben')
+            ->expectParameterValue('RSVP', 'TRUE')
+            ->expectParameterValue('PARTSTAT', ParticipationStatus::needs_action()->value);
+    }
 }


### PR DESCRIPTION
Hi, firstly thanks for this and all other spatie package, you guys are awesome!

We make use of this package to generate ics files for outgoing calendar invitations. The package works as expected, except for one issue we have with installed outlook clients and RSVP'ing to events.

Currently when adding an attendee to an event, we only have three options, namely:

1. email
2. name
3. participation status

For majority of clients these suffice, setting the participation status to `ParticipationStatus::needs_action()` displays the RSVP buttons and sends a response email to the organizer.

The generated ATTENDEE string for reference from the above is:

`ATTENDEE;CN=xx@xxxx.com;PARTSTAT=NEEDS-ACTION:MAILTO:xxx@xxx.com` 

The problem comes in with installed outlook clients, displaying the following message:

![image](https://user-images.githubusercontent.com/17425015/138691191-026a874a-9fa5-4986-a8c5-a58b8c815bac.png)

After a bit of digging it turns out the installed outlook clients wants `RSVP=TRUE` in the attendee declaration (similar to what google does when creating an event)

This PR adds the ability to indicate a response is requested when adding an attendee to the event, by means of one new parameter, changing the structure of `->attendee(...)` to the below:

```php
public function attendee(
        string $email,
        string $name = null,
        ParticipationStatus $participationStatus = null,
        bool $requiresResponse = false
    ): Event {
        $this->attendees[] = new CalendarAddress($email, $name, $participationStatus, $requiresResponse);

        return $this;
    }
```

This will append the `RSVP=TRUE` to the attendee string:

`ATTENDEE;CN=xxx@xxx.com;RSVP=TRUE;PARTSTAT=NEEDS-ACTION:MAILTO:xxx@xxx.com`

With this addition, installed outlook clients now identify that the organizer wants a response, and reflects that in the client:

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/17425015/138691905-dc33bb72-118f-4859-bc0d-86ba4e7660fd.png">


This is **not** a breaking change as the default behaviour continues to work like before, this PR only adds the ability to specify that RSVP=TRUE should be added to the ATTENDEE string.

Please let me know if there is something you would like me to change regarding the implementation.





