### PR TITLE
feat: add support for images on events (RFC7986)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,23 @@ Event::create()
     ...
 ```
 
+You can add an image as such:
+
+``` php
+Event::create()
+    ->image('https://spatie.be/logo.svg')
+    ->image('https://spatie.be/logo.svg', 'text/svg+xml')
+    ->image('https://spatie.be/logo.svg', 'text/svg+xml', Display::badge())
+    ...
+```
+
+There are four different image display types:
+
+- `Display::badge()`
+- `Display::graphic()`
+- `Display::fullsize()`
+- `Display::thumbnail()`
+
 After creating your event, it should be added to a calendar. There are multiple options to do this:
 
 ``` php

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -327,11 +327,11 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function image(string $url, ?string $mediaType = null, ?Display $display = null): Event
+    public function image(string $url, ?string $mime = null, ?Display $display = null): Event
     {
         $this->images[] = [
             'url' => $url,
-            'type' => $mediaType,
+            'type' => $mime,
             'display' => $display,
         ];
 

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -465,7 +465,7 @@ class Event extends Component implements HasTimezones
         }
 
         $payload->property(
-            DateTimeProperty::fromDateTime($name, $value->getDateTime(), !$this->isFullDay, $this->withoutTimezone)
+            DateTimeProperty::fromDateTime($name, $value->getDateTime(), ! $this->isFullDay, $this->withoutTimezone)
         );
 
         return $this;

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -327,15 +327,6 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    /**
-     * Adds an image to an Event from a URI.
-     * 
-     * @param string $url URI to the image
-     * @param ?string $mediaType Any valid MIME type.
-     * @param ?Display $display Display type of the image
-     * 
-     * @see RFC7986 https://datatracker.ietf.org/doc/html/rfc7986#section-5.10
-     */
     public function image(string $url, ?string $mediaType = null, ?Display $display = null): Event
     {
         $this->images[] = [

--- a/src/Enums/Display.php
+++ b/src/Enums/Display.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\IcalendarGenerator\Enums;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self badge()
+ * @method static self graphic()
+ * @method static self fullsize()
+ * @method static self thumbnail()
+ */
+class Display extends Enum
+{
+    protected static function values(): array
+    {
+        return [
+            'badge' => 'BADGE',
+            'graphic' => 'GRAPHIC',
+            'fullsize' => 'FULLSIZE',
+            'thumbnail' => 'THUMBNAIL',
+        ];
+    }
+}

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -498,4 +498,26 @@ class EventTest extends TestCase
                 ->expectValue('http://spatie.be/logo.jpg'),
         );
     }
+
+    /** @test */
+    public function it_can_add_an_image_to_an_event()
+    {
+        $payload = Event::create()
+            ->image('http://spatie.be/logo.svg')
+            ->image('http://spatie.be/logo.jpg', 'image/jpeg')
+            ->resolvePayload();
+
+        PayloadExpectation::create($payload)->expectProperty(
+            'IMAGE',
+            fn (PropertyExpectation $expectation) => $expectation
+                ->expectParameterCount(1)
+                ->expectParameterValue('VALUE', 'URI')
+                ->expectValue('http://spatie.be/logo.svg'),
+            fn (PropertyExpectation $expectation) => $expectation
+                ->expectParameterCount(2)
+                ->expectParameterValue('VALUE', 'URI')
+                ->expectParameterValue('FMTTYPE', 'image/jpeg')
+                ->expectValue('http://spatie.be/logo.jpg'),
+        );
+    }
 }

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Spatie\IcalendarGenerator\Components\Alert;
 use Spatie\IcalendarGenerator\Components\Event;
 use Spatie\IcalendarGenerator\Enums\Classification;
+use Spatie\IcalendarGenerator\Enums\Display;
 use Spatie\IcalendarGenerator\Enums\EventStatus;
 use Spatie\IcalendarGenerator\Enums\ParticipationStatus;
 use Spatie\IcalendarGenerator\Enums\RecurrenceFrequency;
@@ -505,6 +506,7 @@ class EventTest extends TestCase
         $payload = Event::create()
             ->image('http://spatie.be/logo.svg')
             ->image('http://spatie.be/logo.jpg', 'image/jpeg')
+            ->image('http://spatie.be/logo.png', 'image/png', Display::badge())
             ->resolvePayload();
 
         PayloadExpectation::create($payload)->expectProperty(
@@ -518,6 +520,12 @@ class EventTest extends TestCase
                 ->expectParameterValue('VALUE', 'URI')
                 ->expectParameterValue('FMTTYPE', 'image/jpeg')
                 ->expectValue('http://spatie.be/logo.jpg'),
+            fn (PropertyExpectation $expectation) => $expectation
+                ->expectParameterCount(3)
+                ->expectParameterValue('VALUE', 'URI')
+                ->expectParameterValue('FMTTYPE', 'image/png')
+                ->expectParameterValue('DISPLAY', 'BADGE')
+                ->expectValue('http://spatie.be/logo.png'),
         );
     }
 }


### PR DESCRIPTION
RFC7986 adds the ability to attach Images to various iCal components, including Events.

This PR implements _partial_ support for this, via URI-based images rather than embedded binary/base64 images.