### PR TITLE
Add calendar source parameter

### DIFF
--- a/src/Components/Calendar.php
+++ b/src/Components/Calendar.php
@@ -34,6 +34,8 @@ class Calendar extends Component implements HasTimezones
 
     private ?string $productIdentifier = null;
 
+    private ?string $source = null;
+
     public static function create(string $name = null): Calendar
     {
         return new self($name);
@@ -146,6 +148,18 @@ class Calendar extends Component implements HasTimezones
         return $this;
     }
 
+    /**
+     * Identifies a location where a client can retrieve updated data for the calendar.
+     *
+     * @link https://datatracker.ietf.org/doc/html/rfc7986#section-5.7
+     */
+    public function source(string $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
     public function get(): string
     {
         return $this->toString();
@@ -172,6 +186,10 @@ class Calendar extends Component implements HasTimezones
             ->optional(
                 $this->description,
                 fn () => TextProperty::create('DESCRIPTION', $this->description)->addAlias('X-WR-CALDESC')
+            )
+            ->optional(
+                $this->source,
+                fn () => TextProperty::create('SOURCE', $this->source)->addParameter(new Parameter('VALUE', 'URI'))
             )
             ->optional(
                 $this->refreshInterval,

--- a/tests/Components/CalendarTest.php
+++ b/tests/Components/CalendarTest.php
@@ -155,6 +155,18 @@ class CalendarTest extends TestCase
     }
 
     /** @test */
+    public function a_source_can_be_set()
+    {
+        $payload = Calendar::create()
+            ->source('https://example.org/cal.ics')
+            ->resolvePayload();
+
+        PropertyExpectation::create($payload, 'SOURCE')
+            ->expectValue('https://example.org/cal.ics')
+            ->expectParameterValue('VALUE', 'URI');
+    }
+
+    /** @test */
     public function it_will_automatically_add_multiple_timezone_components()
     {
         Carbon::setTestNow(new CarbonImmutable('1 august 2020'));


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7986#section-5.8
> Property Name:  SOURCE
> Purpose:        This property identifies a URI where calendar data can
>                 be refreshed from.