### PR TITLE
Add google meet and microsoft teams to event

### DIFF
--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -44,6 +44,10 @@ class Event extends Component implements HasTimezones
 
     private ?string $addressName = null;
 
+    private ?string $googleConference = null;
+
+    private ?string $microsoftTeams = null;
+
     private ?float $lat = null;
 
     private ?float $lng = null;
@@ -160,6 +164,20 @@ class Event extends Component implements HasTimezones
     public function addressName(string $name): Event
     {
         $this->addressName = $name;
+
+        return $this;
+    }
+
+    public function googleConference(string $googleConference): Event
+    {
+        $this->googleConference = $googleConference;
+
+        return $this;
+    }
+
+    public function microsoftTeams(string $microsoftTeams): Event
+    {
+        $this->microsoftTeams = $microsoftTeams;
 
         return $this;
     }
@@ -392,6 +410,14 @@ class Event extends Component implements HasTimezones
             ->optional(
                 $this->status,
                 fn () => TextProperty::createFromEnum('STATUS', $this->status)
+            )
+            ->optional(
+                $this->googleConference,
+                fn () => TextProperty::create('X-GOOGLE-CONFERENCE', $this->googleConference)
+            )
+            ->optional(
+                $this->microsoftTeams,
+                fn () => TextProperty::create('X-MICROSOFT-SKYPETEAMSMEETINGURL', $this->microsoftTeams)
             )
             ->optional(
                 $this->transparent,

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -48,10 +48,13 @@ class EventTest extends TestCase
             ->endsAt($dateEnds)
             ->address('Antwerp')
             ->addressName('Spatie')
+            ->googleConference('Spatie')
+            ->googleConference('https://meet.google.com/aaa-aaa-aaa')
+            ->microsoftTeams('https://teams.microsoft.com/l/meetup-join/aaa-aaa-aaa')
             ->resolvePayload();
 
         PayloadExpectation::create($payload)
-            ->expectPropertyCount(8)
+            ->expectPropertyCount(10)
             ->expectPropertyValue('SUMMARY', 'An introduction into event sourcing')
             ->expectPropertyValue('DESCRIPTION', 'By Freek Murze')
             ->expectPropertyValue('DTSTAMP', $dateCreated)
@@ -59,6 +62,8 @@ class EventTest extends TestCase
             ->expectPropertyValue('DTEND', $dateEnds)
             ->expectPropertyValue('LOCATION', 'Antwerp')
             ->expectPropertyValue('UID', 'Identifier here')
+            ->expectPropertyValue('X-GOOGLE-CONFERENCE', 'https://meet.google.com/aaa-aaa-aaa')
+            ->expectPropertyValue('X-MICROSOFT-SKYPETEAMSMEETINGURL', 'https://teams.microsoft.com/l/meetup-join/aaa-aaa-aaa')
             ->expectPropertyValue('URL', 'http://example.com/pub/calendars/jsmith/mytime.ics');
     }
 


### PR DESCRIPTION
When video call links add to event by properties notifications are more informative and there is an option to join directly from the notification
So I added properties for
- Google meet
- Microsoft teams