### PR TITLE
Fix GEO coordinates on locale with comma as decimal separator

### DIFF
--- a/src/Properties/CoordinatesProperty.php
+++ b/src/Properties/CoordinatesProperty.php
@@ -22,7 +22,7 @@ class CoordinatesProperty extends Property
 
     public function getValue(): string
     {
-        return "{$this->lat};{$this->lng}";
+        return json_encode($this->lat) . ';' . json_encode($this->lng);
     }
 
     public function getOriginalValue(): array

--- a/tests/Properties/CoordinatesPropertyTest.php
+++ b/tests/Properties/CoordinatesPropertyTest.php
@@ -1,9 +1,21 @@
 <?php
 
+namespace Spatie\IcalendarGenerator\Tests\Properties;
+
 use Spatie\IcalendarGenerator\Properties\CoordinatesProperty;
 use Spatie\IcalendarGenerator\Tests\PropertyExpectation;
 
 test('it can create a coordinates property type', function () {
+    $propertyType = new CoordinatesProperty('GEO', 10.5, 20.5);
+
+    PropertyExpectation::create($propertyType)
+        ->expectName('GEO')
+        ->expectOutput('10.5;20.5')
+        ->expectValue(['lat' => 10.5, 'lng' => 20.5]);
+});
+
+test('it_has_dot_as_decimal_point', function () {
+    setlocale(LC_ALL, 'de_DE.UTF-8');
     $propertyType = new CoordinatesProperty('GEO', 10.5, 20.5);
 
     PropertyExpectation::create($propertyType)


### PR DESCRIPTION
Some locales like "de_DE" use a "," as decimal separator. When outputting floats, PHP < 8.0 uses the locale-dependent decimal point - leading to "3.14" for English locales but "3,14" for German.

PHP 8 fixes this: https://wiki.php.net/rfc/locale_independent_float_to_string

This commit fixes this for PHP 7.x by utilizing json_encode's own locale-independent float serialization code.