### PR TITLE
Fix 2 bugs introduced in https://github.com/spatie/icalendar-generator/pull/110

### DIFF
--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -73,9 +73,9 @@ class Event extends Component implements HasTimezones
     /** @var RRule|string|null */
     private $rrule = null;
 
-    private ?DateTime $rruleStarting = null;
+    private ?DateTimeInterface $rruleStarting = null;
 
-    private ?DateTime $rruleUntil = null;
+    private ?DateTimeInterface $rruleUntil = null;
 
     /** @var \Spatie\IcalendarGenerator\ValueObjects\DateTimeValue[] */
     private array $recurrence_dates = [];
@@ -460,7 +460,7 @@ class Event extends Component implements HasTimezones
             ->optional(
                 $this->rrule,
                 fn () => is_string($this->rrule)
-                    ? TextProperty::create('RRULE', $this->rrule)
+                    ? TextProperty::create('RRULE', $this->rrule)->withoutEscaping()
                     : RRuleProperty::create('RRULE', $this->rrule)
             )
             ->multiple(

--- a/tests/Components/EventTest.php
+++ b/tests/Components/EventTest.php
@@ -249,7 +249,7 @@ test('it can set an address without name', function () {
         ->expectValue('Antwerp');
 });
 
-test('it an set a recurrence rule', function () {
+test('it can set a recurrence rule', function () {
     $payload = Event::create('An introduction into event sourcing')
         ->rrule($rrule = RRule::frequency(RecurrenceFrequency::daily()))
         ->resolvePayload();
@@ -258,13 +258,14 @@ test('it an set a recurrence rule', function () {
         ->expectValue($rrule);
 });
 
-test('it an set a recurrence rule as a string', function () {
-    $payload = Event::create('An introduction into event sourcing')
+test('it can set a recurrence rule as a string', function () {
+    $payload = Event::create('A recurring event')
         ->rruleAsString($rrule = 'FREQ=DAILY;INTERVAL=2;UNTIL=20240301T230000Z')
         ->resolvePayload();
 
     PropertyExpectation::create($payload, 'RRULE')
-        ->expectValue($rrule);
+        ->expectValue($rrule)
+        ->expectOutput($rrule);
 });
 
 test('it can create an event without timezones', function () {


### PR DESCRIPTION
Sorry, my PR https://github.com/spatie/icalendar-generator/pull/110 included 2 bugs:
- `Event::rruleAsString()` allows `DateTimeInterface` in the second and third argument but the property type is limited to `DateTime` (so passing `DateTimeImmutable` throws a `TypeError`)
- The expected output for `FREQ=DAILY;INTERVAL=2` is `FREQ=DAILY;INTERVAL=2` but we get a backslash-escaped output `FREQ=DAILY\;INTERVAL=2` (which is also invalid according to https://icalendar.org/validator.html)

This PR fixes both bugs.

Thank you for this great package!