### PR TITLE
feat: use rfc 6868 escaping

### DIFF
--- a/src/Properties/Parameter.php
+++ b/src/Properties/Parameter.php
@@ -40,11 +40,14 @@ class Parameter
         }
 
         $replacements = [
-            '\\' => '\\\\',
-            '"' => '\\"',
+            // RFC 5545
+            '\\' => '\\\\', 
             ',' => '\\,',
             ';' => '\\;',
-            "\n" => '\\n',
+            // RFC 6868
+            '^' => '^^',
+            '"' => '^\'', 
+            PHP_EOL => '^n',
         ];
 
         return str_replace(array_keys($replacements), $replacements, $value);

--- a/tests/Properties/ParameterTest.php
+++ b/tests/Properties/ParameterTest.php
@@ -63,6 +63,11 @@ test('it can disable escaping', function () {
         'a return \n ',
         (new Parameter('', 'a return \n ', true))->getValue()
     );
+
+    assertEquals(
+        'a return ^ ',
+        (new Parameter('', 'a return ^ ', true))->getValue()
+    );
 });
 
 test('it can format a boolean', function () {

--- a/tests/Properties/ParameterTest.php
+++ b/tests/Properties/ParameterTest.php
@@ -13,7 +13,7 @@ test('it replaces all illegal characters', function () {
     );
 
     assertEquals(
-        'a quote \\" ',
+        'a quote ^\' ',
         (new Parameter('', 'a quote " '))->getValue()
     );
 
@@ -28,8 +28,13 @@ test('it replaces all illegal characters', function () {
     );
 
     assertEquals(
-        'a return \\\n ',
-        (new Parameter('', 'a return \n '))->getValue()
+        'a return ^n ',
+        (new Parameter('', 'a return '.PHP_EOL.' '))->getValue()
+    );
+
+    assertEquals(
+        'a circumflex accent ^^ ',
+        (new Parameter('', 'a circumflex accent ^ '))->getValue()
     );
 });
 


### PR DESCRIPTION
This PR makes sure properties are escaped according to [RFC 6868](https://datatracker.ietf.org/doc/html/rfc6868), which updates the RFC 5545 escaping. This solves #129.