### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/ComponentPayload.php
+++ b/src/ComponentPayload.php
@@ -25,7 +25,7 @@ class ComponentPayload
         $this->type = $type;
     }
 
-    public function property(Property $property, array $parameters = null): ComponentPayload
+    public function property(Property $property, ?array $parameters = null): ComponentPayload
     {
         $property->addParameters($parameters ?? []);
 

--- a/src/Components/Alert.php
+++ b/src/Components/Alert.php
@@ -27,12 +27,12 @@ class Alert extends Component
 
     private bool $withoutTimezone = false;
 
-    public static function date(DateTimeInterface $date, string $description = null): Alert
+    public static function date(DateTimeInterface $date, ?string $description = null): Alert
     {
         return static::create($description)->triggerDate($date);
     }
 
-    public static function minutesBeforeStart(int $minutes, string $description = null): Alert
+    public static function minutesBeforeStart(int $minutes, ?string $description = null): Alert
     {
         $interval = new DateInterval("PT{$minutes}M");
         $interval->invert = 1;
@@ -40,12 +40,12 @@ class Alert extends Component
         return static::create($description)->triggerAtStart($interval);
     }
 
-    public static function minutesAfterStart(int $minutes, string $description = null): Alert
+    public static function minutesAfterStart(int $minutes, ?string $description = null): Alert
     {
         return static::create($description)->triggerAtStart(new DateInterval("PT{$minutes}M"));
     }
 
-    public static function minutesBeforeEnd(int $minutes, string $description = null): Alert
+    public static function minutesBeforeEnd(int $minutes, ?string $description = null): Alert
     {
         $interval = new DateInterval("PT{$minutes}M");
         $interval->invert = 1;
@@ -53,17 +53,17 @@ class Alert extends Component
         return static::create($description)->triggerAtEnd($interval);
     }
 
-    public static function minutesAfterEnd(int $minutes, string $description = null): Alert
+    public static function minutesAfterEnd(int $minutes, ?string $description = null): Alert
     {
         return static::create($description)->triggerAtEnd(new DateInterval("PT{$minutes}M"));
     }
 
-    private static function create(string $description = null): Alert
+    private static function create(?string $description = null): Alert
     {
         return new self($description);
     }
 
-    public function __construct(string $description = null)
+    public function __construct(?string $description = null)
     {
         $this->message = $description;
     }

--- a/src/Components/Calendar.php
+++ b/src/Components/Calendar.php
@@ -36,12 +36,12 @@ class Calendar extends Component implements HasTimezones
 
     private ?string $source = null;
 
-    public static function create(string $name = null): Calendar
+    public static function create(?string $name = null): Calendar
     {
         return new self($name);
     }
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         $this->name = $name;
     }

--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -91,12 +91,12 @@ class Event extends Component implements HasTimezones
     /** @var array[] */
     private array $images = [];
 
-    public static function create(string $name = null): Event
+    public static function create(?string $name = null): Event
     {
         return new self($name);
     }
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         $this->name = $name;
         $this->uuid = uniqid();
@@ -128,8 +128,12 @@ class Event extends Component implements HasTimezones
     public function endsAt(DateTimeInterface $ends, bool $withTime = true): Event
     {
         if ($this->isFullDay) {
-            // The DTEND is the non-inclusive end of the event.
-            $ends = $ends->modify('+1 day');
+            if (method_exists($ends, 'modify')) {
+                $ends = $ends->modify('+1 day');
+            } else {
+                throw new \LogicException('The provided DateTimeInterface instance does not support the modify method.');
+            }
+
             $this->ends = DateTimeValue::create($ends, false);
         } else {
             $this->ends = DateTimeValue::create($ends, $withTime);
@@ -164,7 +168,7 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function address(string $address, string $name = null): Event
+    public function address(string $address, ?string $name = null): Event
     {
         $this->address = $address;
 
@@ -240,21 +244,21 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function alertAt(DateTimeInterface $alert, string $message = null)
+    public function alertAt(DateTimeInterface $alert, ?string $message = null)
     {
         $this->alerts[] = Alert::date($alert, $message);
 
         return $this;
     }
 
-    public function alertMinutesBefore(int $minutes, string $message = null): Event
+    public function alertMinutesBefore(int $minutes, ?string $message = null): Event
     {
         $this->alerts[] = Alert::minutesBeforeStart($minutes, $message);
 
         return $this;
     }
 
-    public function alertMinutesAfter(int $minutes, string $message = null): Event
+    public function alertMinutesAfter(int $minutes, ?string $message = null): Event
     {
         $this->alerts[] = Alert::minutesAfterEnd($minutes, $message);
 
@@ -277,8 +281,8 @@ class Event extends Component implements HasTimezones
 
     public function attendee(
         string $email,
-        string $name = null,
-        ParticipationStatus $participationStatus = null,
+        ?string $name = null,
+        ?ParticipationStatus $participationStatus = null,
         bool $requiresResponse = false
     ): Event {
         $this->attendees[] = new CalendarAddress($email, $name, $participationStatus, $requiresResponse);
@@ -286,7 +290,7 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function organizer(string $email, string $name = null): Event
+    public function organizer(string $email, ?string $name = null): Event
     {
         $this->organizer = new CalendarAddress($email, $name);
 
@@ -307,7 +311,7 @@ class Event extends Component implements HasTimezones
         return $this;
     }
 
-    public function rruleAsString(string $rrule, ?DateTimeInterface $starting = null, DateTimeInterface $until = null): Event
+    public function rruleAsString(string $rrule, ?DateTimeInterface $starting = null, ?DateTimeInterface $until = null): Event
     {
         $this->rrule = $rrule;
         $this->rruleStarting = $starting;

--- a/src/ValueObjects/CalendarAddress.php
+++ b/src/ValueObjects/CalendarAddress.php
@@ -17,8 +17,8 @@ class CalendarAddress
 
     public function __construct(
         string $email,
-        string $name = null,
-        ParticipationStatus $participationStatus = null,
+        ?string $name = null,
+        ?ParticipationStatus $participationStatus = null,
         bool $requiresResponse = false
     ) {
         $this->email = $email;

--- a/tests/Builders/ComponentBuilderTest.php
+++ b/tests/Builders/ComponentBuilderTest.php
@@ -16,10 +16,10 @@ test('it can build a component payload with properties', function () {
 
     assertEquals(
         <<<EOT
-BEGIN:VTEST\r
-location:Antwerp\r
-END:VTEST
-EOT,
+            BEGIN:VTEST\r
+            location:Antwerp\r
+            END:VTEST
+            EOT,
         $builder->build()
     );
 });
@@ -35,11 +35,11 @@ test('it can build a component payload with property alias', function () {
 
     assertEquals(
         <<<EOT
-BEGIN:VTEST\r
-location:Antwerp\r
-geo:Antwerp\r
-END:VTEST
-EOT,
+            BEGIN:VTEST\r
+            location:Antwerp\r
+            geo:Antwerp\r
+            END:VTEST
+            EOT,
         $builder->build()
     );
 });
@@ -53,12 +53,12 @@ test('it can build a component payload with sub-components', function () {
 
     assertEquals(
         <<<EOT
-BEGIN:VTEST\r
-BEGIN:VDUMMY\r
-name:SUBCOMPONENT\r
-END:VDUMMY\r
-END:VTEST
-EOT,
+            BEGIN:VTEST\r
+            BEGIN:VDUMMY\r
+            name:SUBCOMPONENT\r
+            END:VDUMMY\r
+            END:VTEST
+            EOT,
         $builder->build()
     );
 });
@@ -72,12 +72,12 @@ test('it will chip a line when it becomes too long', function () {
 
     assertEquals(
         <<<EOT
-BEGIN:VTEST\r
-location:This is a really long text. Possibly you will never write a text l\r
- ike this in a property. But hey we support the RFC so let us chip it! You \r
- can maybe write some HTML in here that will make it longer than usual.\r
-END:VTEST
-EOT,
+            BEGIN:VTEST\r
+            location:This is a really long text. Possibly you will never write a text l\r
+             ike this in a property. But hey we support the RFC so let us chip it! You \r
+             can maybe write some HTML in here that will make it longer than usual.\r
+            END:VTEST
+            EOT,
         $builder->build()
     );
 });

--- a/tests/Components/CalendarTest.php
+++ b/tests/Components/CalendarTest.php
@@ -234,75 +234,75 @@ test('it will automatically add timezone component', function () {
 
     assertInstanceOf(Timezone::class, $utcComponent);
     assertEquals(<<<EOT
-BEGIN:VTIMEZONE\r
-TZID:UTC\r
-BEGIN:STANDARD\r
-DTSTART:20180406T000000\r
-TZOFFSETFROM:+0000\r
-TZOFFSETTO:+0000\r
-END:STANDARD\r
-END:VTIMEZONE
-EOT, $utcComponent->toString());
+        BEGIN:VTIMEZONE\r
+        TZID:UTC\r
+        BEGIN:STANDARD\r
+        DTSTART:20180406T000000\r
+        TZOFFSETFROM:+0000\r
+        TZOFFSETTO:+0000\r
+        END:STANDARD\r
+        END:VTIMEZONE
+        EOT, $utcComponent->toString());
 
     /** @var \Spatie\IcalendarGenerator\Components\Timezone $alternativeTimezoneComponent */
     $alternativeTimezoneComponent = $subComponents[1];
 
     assertInstanceOf(Timezone::class, $alternativeTimezoneComponent);
     assertEquals(<<<EOT
-BEGIN:VTIMEZONE\r
-TZID:Europe/Brussels\r
-BEGIN:STANDARD\r
-DTSTART:20191027T030000\r
-TZOFFSETFROM:+0200\r
-TZOFFSETTO:+0100\r
-END:STANDARD\r
-BEGIN:DAYLIGHT\r
-DTSTART:20200329T020000\r
-TZOFFSETFROM:+0100\r
-TZOFFSETTO:+0200\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-DTSTART:20201025T030000\r
-TZOFFSETFROM:+0200\r
-TZOFFSETTO:+0100\r
-END:STANDARD\r
-BEGIN:DAYLIGHT\r
-DTSTART:20210328T020000\r
-TZOFFSETFROM:+0100\r
-TZOFFSETTO:+0200\r
-END:DAYLIGHT\r
-END:VTIMEZONE
-EOT, $alternativeTimezoneComponent->toString());
+        BEGIN:VTIMEZONE\r
+        TZID:Europe/Brussels\r
+        BEGIN:STANDARD\r
+        DTSTART:20191027T030000\r
+        TZOFFSETFROM:+0200\r
+        TZOFFSETTO:+0100\r
+        END:STANDARD\r
+        BEGIN:DAYLIGHT\r
+        DTSTART:20200329T020000\r
+        TZOFFSETFROM:+0100\r
+        TZOFFSETTO:+0200\r
+        END:DAYLIGHT\r
+        BEGIN:STANDARD\r
+        DTSTART:20201025T030000\r
+        TZOFFSETFROM:+0200\r
+        TZOFFSETTO:+0100\r
+        END:STANDARD\r
+        BEGIN:DAYLIGHT\r
+        DTSTART:20210328T020000\r
+        TZOFFSETFROM:+0100\r
+        TZOFFSETTO:+0200\r
+        END:DAYLIGHT\r
+        END:VTIMEZONE
+        EOT, $alternativeTimezoneComponent->toString());
 
     /** @var \Spatie\IcalendarGenerator\Components\Timezone $negativeOffsetTimezoneComponent */
     $negativeOffsetTimezoneComponent = $subComponents[2];
 
     assertInstanceOf(Timezone::class, $negativeOffsetTimezoneComponent);
     assertEquals(<<<EOT
-BEGIN:VTIMEZONE\r
-TZID:America/New_York\r
-BEGIN:STANDARD\r
-DTSTART:20191103T020000\r
-TZOFFSETFROM:-0400\r
-TZOFFSETTO:-0500\r
-END:STANDARD\r
-BEGIN:DAYLIGHT\r
-DTSTART:20200308T020000\r
-TZOFFSETFROM:-0500\r
-TZOFFSETTO:-0400\r
-END:DAYLIGHT\r
-BEGIN:STANDARD\r
-DTSTART:20201101T020000\r
-TZOFFSETFROM:-0400\r
-TZOFFSETTO:-0500\r
-END:STANDARD\r
-BEGIN:DAYLIGHT\r
-DTSTART:20210314T020000\r
-TZOFFSETFROM:-0500\r
-TZOFFSETTO:-0400\r
-END:DAYLIGHT\r
-END:VTIMEZONE
-EOT, $negativeOffsetTimezoneComponent->toString());
+        BEGIN:VTIMEZONE\r
+        TZID:America/New_York\r
+        BEGIN:STANDARD\r
+        DTSTART:20191103T020000\r
+        TZOFFSETFROM:-0400\r
+        TZOFFSETTO:-0500\r
+        END:STANDARD\r
+        BEGIN:DAYLIGHT\r
+        DTSTART:20200308T020000\r
+        TZOFFSETFROM:-0500\r
+        TZOFFSETTO:-0400\r
+        END:DAYLIGHT\r
+        BEGIN:STANDARD\r
+        DTSTART:20201101T020000\r
+        TZOFFSETFROM:-0400\r
+        TZOFFSETTO:-0500\r
+        END:STANDARD\r
+        BEGIN:DAYLIGHT\r
+        DTSTART:20210314T020000\r
+        TZOFFSETFROM:-0500\r
+        TZOFFSETTO:-0400\r
+        END:DAYLIGHT\r
+        END:VTIMEZONE
+        EOT, $negativeOffsetTimezoneComponent->toString());
 });
 
 test('it can add timezone components manually', function () {

--- a/tests/PropertyExpectation.php
+++ b/tests/PropertyExpectation.php
@@ -15,7 +15,7 @@ class PropertyExpectation
      *
      * @return static
      */
-    public static function create($instance, string $name = null): self
+    public static function create($instance, ?string $name = null): self
     {
         if ($instance instanceof Property) {
             return new self($instance);


### PR DESCRIPTION
Hi,

I noticed that the current version of Psalm (5.24.0 to 5.26.1) does not support PHP 8.4 yet (https://github.com/vimeo/psalm/pull/10928). Due to this limitation, I have not added PHP 8.4 to the test matrix in GitHub Actions.

Once a compatible version of Psalm is released, we can update the dependency and include PHP 8.4 in the CI tests to ensure full compatibility.

Thank you for reviewing this PR! Let me know if there are any changes or questions.

