### PR TITLE
allow for zero-second durations.

### DIFF
--- a/src/ValueObjects/DurationValue.php
+++ b/src/ValueObjects/DurationValue.php
@@ -58,6 +58,10 @@ class DurationValue
             $value .= "{$this->interval->s}S";
         }
 
+        if ($value == "P" || $value == "-P") {
+            return "PT0S";
+        }
+
         return $value;
     }
 }

--- a/tests/ValueObjects/DurationValueTest.php
+++ b/tests/ValueObjects/DurationValueTest.php
@@ -22,6 +22,12 @@ test('it can create a duration property with all properties', function () {
     assertEquals('P4DT3H2M1S', $value->format());
 });
 
+test('it can create 0 seconds duration', function () {
+    $value = DurationValue::create('PT0S');
+
+    assertEquals('PT0S', $value->format());
+});
+
 test('it can use a regular string as duration', function () {
     $value = DurationValue::create('PT5M');
 


### PR DESCRIPTION
Event start alerts generated by this program are not available in Apple Calendar.
Apple Calendar express `TRIGGER` of event start alerts as `PT0S` on export.
I think `TRIGGER:P0D` or `TRIGGER:PT0S` better then `TRIGGER:P` because RFC5545 not allows duration without digit.

In this pull request change to use `TRIGGER:PT0S` on 0 seconds duration.

P.S.
Google Calendar express `TRIGGER` of event start alerts as `PT0D` on export.
Outlook and Google Calendar can load alert `TRIGGER:P`.

