### PR TITLE
Restore exclusive DTEND for full day events

### DIFF
--- a/src/Components/Event.php
+++ b/src/Components/Event.php
@@ -260,9 +260,9 @@ class Event extends Component implements HasTimezones
             );
         }
 
-        if ($this->ends) {
+        if ($end = $this->resolveEnd()) {
             $payload->property(
-                DateTimeProperty::fromDateTime('DTEND', $this->ends->getDateTime(), ! $this->isFullDay, $this->withTimezone)
+                DateTimeProperty::fromDateTime('DTEND', $end->getDateTime(), ! $this->isFullDay, $this->withTimezone)
             );
         }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -71,7 +71,7 @@ test('it can create a full day event', function () {
                 ->uniqueIdentifier('uuid_2')
                 ->createdAt(new DateTime('6 March 2019 15:00:00'))
                 ->startsAt(new DateTime('6 March 2019'))
-                ->endsAt(new DateTime('7 March 2019'))
+                ->endsAt(new DateTime('6 March 2019'))
         )
         ->get();
 
@@ -86,7 +86,7 @@ test('it can create a full day event irrespective of param ordering', function (
                 ->uniqueIdentifier('uuid_2')
                 ->createdAt(new DateTime('6 March 2019 15:00:00'))
                 ->startsAt(new DateTime('6 March 2019'))
-                ->endsAt(new DateTime('7 March 2019'))
+                ->endsAt(new DateTime('6 March 2019'))
                 ->fullDay()
         )
         ->get();


### PR DESCRIPTION
Fixes #169.

RFC 5545 defines `DTEND;VALUE=DATE` as non-inclusive, the day after the last day of the event. That behaviour was added in #128 and survived the 3.1.0 refactor as `resolveEnd()`, but the 3.2.0 refactor rewrote the `DTEND` line in `resolveProperties()` to read `$this->ends` directly, leaving `resolveEnd()` as dead code. Since then a full day event ending on the 27th emits `DTEND;VALUE=DATE:20260827`, so calendar clients display it ending on the 26th.

The fix restores the exact 3.1.0 call site: `DTEND` is built from `resolveEnd()`, which applies the `+1 day` at resolve time, keeping the result independent of whether `fullDay()` is called before or after `endsAt()`.

The existing full day snapshots did not catch the regression because their fixtures were changed to pass an already-exclusive end date. This PR reverts both fixtures to the inclusive date (`6 March 2019`), so the unchanged snapshots (`DTEND;VALUE=DATE:20190307`) now guard the bump again. With the fixtures reverted, both tests fail on current `main` and pass with this change.

Full suite and PHPStan pass.
