### PR TITLE
Add support for Pest 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "nesbot/carbon": "^3.5",
         "larapack/dd": "^1.1",
-        "pestphp/pest": "^2.34 || ^3.0 || ^4.0",
+        "pestphp/pest": "^2.34 || ^3.0 || ^4.0 || ^5.0",
         "spatie/pest-plugin-snapshots": "^2.1",
         "phpstan/phpstan" : "^2.0"
     },

--- a/tests/Builders/ComponentBuilderTest.php
+++ b/tests/Builders/ComponentBuilderTest.php
@@ -70,11 +70,14 @@ test('it will chip a line when it becomes too long', function () {
 
     $builder = new ComponentBuilder($payload);
 
+    // The folded line ends on a space, written as a variable so it does not get trimmed away
+    $trailingSpace = ' ';
+
     assertEquals(
         <<<EOT
             BEGIN:VTEST\r
             location:This is a really long text. Possibly you will never write a text l\r
-             ike this in a property. But hey we support the RFC so let us chip it! You ${''}\r
+             ike this in a property. But hey we support the RFC so let us chip it! You{$trailingSpace}\r
              can maybe write some HTML in here that will make it longer than usual.\r
             END:VTEST
             EOT,


### PR DESCRIPTION
Widens the `pestphp/pest` constraint to allow 5.x. Pest 5 needs PHP ^8.4, so the 8.2/8.3 matrix jobs keep resolving to Pest 4.

Also replaces `${''}` in `ComponentBuilderTest` (a placeholder that kept the trailing space in the heredoc from being trimmed) with a `$trailingSpace` variable. It is removed in PHP 9 and Pest 5 reports it as a warning.